### PR TITLE
ci: Enable quality checks for PRs to week-* branches

### DIFF
--- a/.github/workflows/quality-and-tests.yml
+++ b/.github/workflows/quality-and-tests.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - develop
+      - 'week-*'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Problem

Currently, the `quality-and-tests.yml` workflow only runs on PRs targeting `main` or `develop`:

```yaml
pull_request:
  branches:
    - main
    - develop  # ❌ Missing week-*
```

**Impact**: PRs to week integration branches (e.g., PR #61 → `week-2`) have NO automated quality validation.

## Solution

Add `week-*` pattern to `pull_request` triggers:

```yaml
pull_request:
  branches:
    - main
    - develop
    - 'week-*'  # ✅ Now validates PRs to week branches
```

## Benefits

- ✅ **Prevent quality issues**: All PRs validate BEFORE merge
- ✅ **Immediate feedback**: GitHub checks show red/green status
- ✅ **Consistent standards**: Same validation as main/develop
- ✅ **Reduce debugging**: Catch issues in PRs, not after merge

## Testing

After merge, PR #61 and future PRs to `week-*` branches will automatically run:
1. PHPCS (WordPress Coding Standards)
2. PHPStan (Static Analysis Level 6+)
3. PHPUnit (108 tests, 355 assertions)
4. Frontend Build (Webpack production)

## Related

- Improves workflow for Week 2-9 development sprints
- Supports branching strategy: `feature/*` → `week-N` → `main`