### PR TITLE
chore: Add YAML frontmatter to VS Code custom instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,33 +40,14 @@ This is an **8-week WordPress website development project** for FibraSOMA's corp
 
 ## 📋 Path-Specific Instructions
 
-For **language-specific conventions and quality standards**, see:
+The following instruction files apply automatically based on file type. VS Code will load them when working with matching files.
 
-- **PHP Files** (`**/*.php`): `.github/instructions/php.instructions.md`
-  - WordPress Coding Standards (PHPCS)
-  - Security escaping patterns (esc_html, esc_url, wp_kses_post)
-  - SOMA theme architecture and PSR-4 conventions
-  - Quality gates (PHPCBF, PHPStan Level 6+)
-  - Common PHPCS errors and fixes
+**Available instruction files:**
+- `.github/instructions/php.instructions.md` → PHP files (`**/*.php`)
+- `.github/instructions/documentation-language.instructions.md` → Documentation and language policy
+- `.github/instructions/github-workflow.instructions.md` → GitHub operations and workflow
 
-- **Documentation & Language Policy** (all docs, comments, commits): `.github/instructions/documentation-language.instructions.md`
-  - English-only policy for technical content
-  - Markdown best practices and structure
-  - Writing style guide (tone, voice, examples)
-  - Commit message standards (Conventional Commits)
-  - Pull Request templates and descriptions
-  - Code commenting conventions (PHP, JS, CSS)
-  - Translation and i18n guidelines
-
-- **GitHub Workflow** (all GitHub operations): `.github/instructions/github-workflow.instructions.md`
-  - Branch management (feature, fix, week-N)
-  - Issue and PR management
-  - Labels and milestones
-  - GitHub CLI commands (ALWAYS use `| cat`)
-  - Release and deployment flow
-  - CI/CD workflows
-
-**Note**: Path-specific instructions take precedence over general guidelines for their respective file types.
+**Note**: These files use YAML frontmatter with `applyTo` patterns and are automatically detected by VS Code.
 
 ---
 

--- a/.github/instructions/documentation-language.instructions.md
+++ b/.github/instructions/documentation-language.instructions.md
@@ -1,3 +1,9 @@
+---
+description: Documentation standards and language policy for all project files
+name: Documentation & Language Policy
+applyTo: "**"
+---
+
 # Documentation and Language Policy Instructions
 
 **Applies to**: All documentation files, code comments, commit messages, and project communication  

--- a/.github/instructions/github-workflow.instructions.md
+++ b/.github/instructions/github-workflow.instructions.md
@@ -1,3 +1,9 @@
+---
+description: GitHub workflow standards including branch management, PRs, issues, and releases
+name: GitHub Workflow
+applyTo: "**"
+---
+
 # GitHub Workflow Instructions for FibraSOMA Project
 
 **Applies to**: All GitHub operations, branch management, issues, PRs, releases, and deployments  


### PR DESCRIPTION
Updates custom instruction files to include proper YAML frontmatter for automatic VS Code Copilot detection.

## 📝 Changes

1. **documentation-language.instructions.md**
   - Added YAML frontmatter with `applyTo: "**"`
   - Enables automatic application to all files

2. **github-workflow.instructions.md**
   - Added YAML frontmatter with `applyTo: "**"`
   - Ensures workflow instructions are followed globally

3. **copilot-instructions.md**
   - Simplified references to instruction files
   - Added note about automatic detection via YAML frontmatter

## ✅ Benefits

- VS Code Copilot will now automatically apply instructions based on file context
- php.instructions.md already had proper frontmatter (`applyTo: "**/*.php"`)
- Improves adherence to:
  - Language policy (English for technical docs)
  - GitHub workflow (quality checks before push)
  - PHP coding standards

## 📚 Reference

Based on [VS Code Custom Instructions documentation](https://code.visualstudio.com/docs/copilot/customization/custom-instructions)