### PR TITLE
fix: Add permissions to ci-cd.yml for GitHub releases

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,6 +24,11 @@ on:
                 description: "Version number (e.g., 3.1.1)"
                 required: false
 
+# Permissions needed for creating releases and deployments
+permissions:
+    contents: write
+    deployments: write
+
 env:
     NODE_VERSION: "18"
     PHP_VERSION: "8.1"


### PR DESCRIPTION
**Problem:**
The v3.1.1 release failed during Stage 2 (Build & Release) with error:
`Resource not accessible by integration`

**Root Cause:**
The unified `ci-cd.yml` workflow lacks the necessary permissions to create GitHub releases.

**Solution:**
Add required permissions to workflow:
- `contents: write` - Required for creating releases
- `deployments: write` - Required for deployment tracking

**Impact:**
- Fixes failed v3.1.1 release (run 20346374474)
- Enables complete pipeline execution (Stages 1 → 2 → 3)
- Allows successful deployment to production

**Testing:**
- After merge, will delete tag v3.1.1
- Recreate tag from updated week-2 branch
- Verify full pipeline executes successfully

**Related:**
- Issue #72 (CI/CD unification)
- PR #73 (merged unified workflow)
- Failed run: https://github.com/sanruiz/fibra/actions/runs/20346374474