### PR TITLE
fix: Use wp_get_theme()->get('Version') as single source of truth

### DIFF
--- a/wp-content/themes/soma/includes/Core/Assets.php
+++ b/wp-content/themes/soma/includes/Core/Assets.php
@@ -30,14 +30,7 @@ class Assets implements LoadableInterface {
 	 *
 	 * @var string
 	 */
-	private string $version = '3.1.0';
-
-	/**
-	 * Legacy stylesheet version
-	 *
-	 * @var string
-	 */
-	private string $legacy_version = '2.0.7';
+	private string $version;
 
 	/**
 	 * Get singleton instance
@@ -54,7 +47,10 @@ class Assets implements LoadableInterface {
 	/**
 	 * Private constructor
 	 */
-	private function __construct() {}
+	private function __construct() {
+		// Get version from style.css (single source of truth).
+		$this->version = wp_get_theme()->get( 'Version' );
+	}
 
 	/**
 	 * Prevent cloning
@@ -110,7 +106,7 @@ class Assets implements LoadableInterface {
 	 */
 	public function add_custom_version_to_stylesheet( string $src ): string {
 		if ( strpos( $src, 'style.css' ) !== false ) {
-			$src = add_query_arg( 'ver', $this->legacy_version, $src );
+			$src = add_query_arg( 'ver', $this->version, $src );
 		}
 		return $src;
 	}
@@ -140,7 +136,7 @@ class Assets implements LoadableInterface {
 			'main-styles',
 			$theme_uri . '/css/main.bundle.css',
 			array( 'soma-variables' ),
-			$this->legacy_version
+			$this->version
 		);
 
 		// Scripts.
@@ -148,7 +144,7 @@ class Assets implements LoadableInterface {
 			'main-scripts',
 			$theme_uri . '/js/main.bundle.js',
 			array( 'jquery' ),
-			$this->legacy_version,
+			$this->version,
 			true
 		);
 	}

--- a/wp-content/themes/soma/includes/Core/Theme.php
+++ b/wp-content/themes/soma/includes/Core/Theme.php
@@ -26,13 +26,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Theme {
 
 	/**
-	 * Theme version
-	 *
-	 * @var string
-	 */
-	public const VERSION = '3.1.0';
-
-	/**
 	 * Singleton instance
 	 *
 	 * @var Theme|null
@@ -165,7 +158,7 @@ class Theme {
 	 * @return string
 	 */
 	public function get_version(): string {
-		return self::VERSION;
+		return wp_get_theme()->get( 'Version' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes asset versioning issue where CSS/JS files were loading with outdated version 2.0.7 instead of current 3.1.1, causing browser caching problems and preventing new styles from appearing.

## Changes

- **Assets.php**: Read version from `style.css` header using `wp_get_theme()->get('Version')`
- **Theme.php**: Use `wp_get_theme()->get('Version')` in `get_version()` method
- **Removed**: Hardcoded `$version = '3.1.0'` and `$legacy_version = '2.0.7'` properties
- **Removed**: Hardcoded `VERSION` constant

## Impact

✅ Assets now load with correct version (?ver=3.1.1)
✅ Single source of truth: only `style.css` header needs updating
✅ Proper cache busting for all assets
✅ Future version updates simplified

## Testing

- [x] Assets enqueue with correct version
- [x] No hardcoded version strings in code
- [x] `soma_get_version()` already used this pattern

Closes #76