### PR TITLE
HOTFIX: Fix workflow condition that blocks tag-triggered releases

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -285,9 +285,9 @@ jobs:
         name: 📦 Build & Release
         runs-on: ubuntu-latest
         needs: [code-quality, php-tests, frontend-build]
-        # Only create releases from main branch with version tags
-        # Tags pushed from week-* branches will run quality gates but NOT release
-        if: (startsWith(github.ref, 'refs/tags/v') && github.event.base_ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+        # Only create releases from version tags (v*)
+        # Assumes tags are created from main branch per GitFlow workflow
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
 
         outputs:
             version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## 🔥 Emergency Hotfix

### 🐛 Problem

Tag v3.1.3 was pushed but Build & Release stage didn't execute because the workflow condition was checking `github.event.base_ref` which is **not available** in tag push events.

### ✅ Solution

Simplified the condition from:
```yaml
if: (startsWith(github.ref, 'refs/tags/v') && github.event.base_ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
```

To:
```yaml
if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
```

### 📝 Details

- `github.event.base_ref` only works with branch push events, not tags
- Our GitFlow policy ensures tags are only created from `main` anyway (enforced by workflow)
- Simplified condition now correctly triggers on any `v*` tag push

### 🚀 Next Steps

1. Merge this hotfix
2. Delete tag v3.1.3: `git tag -d v3.1.3 && git push origin :refs/tags/v3.1.3`
3. Recreate tag: `git tag -a v3.1.3 -m "..."`
4. Push tag: `git push origin v3.1.3`
5. Deployment will trigger correctly

### 🔗 Related

- Tag v3.1.3 created but release failed to trigger
- Run #20412662775 skipped Build & Release stage