### PR TITLE
fix(ci): Update github/codeql-action to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,7 @@ jobs:
 
       # Initialize CodeQL tools for scanning
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@45c373516f557556c15d420e3f5e0aa3d64366bc # v3
+        uses: github/codeql-action/init@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -73,6 +73,6 @@ jobs:
 
       # Perform CodeQL Analysis
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@45c373516f557556c15d420e3f5e0aa3d64366bc # v3
+        uses: github/codeql-action/analyze@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

Updates github/codeql-action from v3 to v4.

## Changes

- `github/codeql-action/init@v3` → `github/codeql-action/init@v4` (5d4e8d1)
- `github/codeql-action/analyze@v3` → `github/codeql-action/analyze@v4` (5d4e8d1)

## Context

Follow-up to PR #115 which pinned actions to commit hashes but used v3 instead of v4.

## Related

- PR #115: Original action pinning