### PR TITLE
fix: Restore team-members post type slug for backward compatibility

### DIFF
--- a/wp-content/themes/soma/includes/Core/Enums/PostType.php
+++ b/wp-content/themes/soma/includes/Core/Enums/PostType.php
@@ -27,7 +27,7 @@ enum PostType: string {
 	case PORTFOLIO    = 'portfolio';
 	case NEWS         = 'news';
 	case CAREERS      = 'careers';
-	case TEAM_MEMBERS = 'team_members';
+	case TEAM_MEMBERS = 'team-members';
 
 	/**
 	 * Get the post type value


### PR DESCRIPTION
## Description

Fixes the team-members post type slug that was accidentally changed during v3.0.0 refactoring.

## Changes

- **File**: `wp-content/themes/soma/includes/Core/Enums/PostType.php`
- **Change**: `'team_members'` → `'team-members'`

## Problem

During the v3.0.0 modernization, the post type slug was changed from hyphenated (`team-members`) to underscored (`team_members`), breaking access to existing Team Members posts.

## Solution

Restore the original hyphenated slug to maintain backward compatibility with existing database records.

## Testing

- [x] PHPCS passes locally
- [ ] CI/CD pipeline passes
- [ ] Existing Team Members posts accessible

## Quality Checklist

- [x] Code follows WordPress Coding Standards
- [x] No breaking changes (restoration of original behavior)
- [x] Related issue linked

Closes #119