### PR TITLE
Week 4: Team Members Post Type Fix

### DIFF
--- a/wp-content/themes/soma/includes/Core/Enums/PostType.php
+++ b/wp-content/themes/soma/includes/Core/Enums/PostType.php
@@ -27,7 +27,7 @@ enum PostType: string {
 	case PORTFOLIO    = 'portfolio';
 	case NEWS         = 'news';
 	case CAREERS      = 'careers';
-	case TEAM_MEMBERS = 'team_members';
+	case TEAM_MEMBERS = 'team-members';
 
 	/**
 	 * Get the post type value


### PR DESCRIPTION
## Week 4 Sprint

### Bug Fix
- fix: Restore team-members post type slug for backward compatibility (#119)

### Changes
The team-members post type slug was restored from `'team_members'` to `'team-members'` to maintain backward compatibility with existing posts created before v3.0.0.

### Quality Gates
- ✅ PHPCS clean
- ✅ PHPStan Level 6+ 
- ✅ PHPUnit tests passing
- ✅ Frontend build successful
- ✅ CodeQL security analysis passed

Closes #119