### PR TITLE
Release v3.1.4

### DIFF
--- a/wp-content/themes/soma/CHANGELOG.md
+++ b/wp-content/themes/soma/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.1.4] - 2025-12-29
+
+### Team Members Post Type Slug Fix
+
+This patch release restores backward compatibility for the team-members post type.
+
+---
+
+### 🐛 Fixed
+
+#### Post Type Slug
+- **team-members Post Type** - Restored original hyphenated slug `'team-members'` (was incorrectly changed to `'team_members'` during v3.0.0 refactoring)
+- **Backward Compatibility** - Existing Team Members posts created before v3.0.0 are now accessible again
+- **Database Consistency** - Post type slug now matches existing database records
+
+### 📦 Files Changed
+
+#### Modified
+- `wp-content/themes/soma/includes/Core/Enums/PostType.php` - Changed `TEAM_MEMBERS` enum value from `'team_members'` to `'team-members'`
+
+---
+
+### 🔗 Related Issues & PRs
+
+- **Issue #119**: [fix: team-members post type slug broken after v3.0.0 refactoring](https://github.com/sanruiz/fibra/issues/119) - Closed
+- **PR #120**: [fix: Restore team-members post type slug for backward compatibility](https://github.com/sanruiz/fibra/pull/120) - Merged
+- **PR #121**: [Week 4: Team Members Post Type Fix](https://github.com/sanruiz/fibra/pull/121) - Merged
+
+---
+
 ## [3.1.3] - 2025-12-21
 
 ### Elementor Styles Fix & Security Enhancements

--- a/wp-content/themes/soma/style.css
+++ b/wp-content/themes/soma/style.css
@@ -4,5 +4,5 @@ Theme URI: https://github.com/sanruiz/fibra
 Description: Modern WordPress theme with PSR-4 architecture, ACF flexible content, and Elementor integration.
 Author: Santiago Ramirez
 Author URI: https://github.com/sanruiz
-Version: 3.1.3
+Version: 3.1.4
 */


### PR DESCRIPTION
## Release v3.1.4

### Summary
Patch release to fix the team-members post type slug for backward compatibility.

### Changes
- **Version bump**: 3.1.3 → 3.1.4
- **CHANGELOG.md**: Added v3.1.4 release notes

### Bug Fix Included
- Restored `team-members` post type slug (was incorrectly changed to `team_members` in v3.0.0)

### Quality Gates
- ✅ PHPCS clean
- ✅ PHPStan Level 6+
- ✅ PHPUnit tests passing
- ✅ Frontend build successful

See CHANGELOG.md for full details.