### PR TITLE
docs: Add note about manual issue closure for non-default branch merges

### DIFF
--- a/.github/instructions/github-workflow.instructions.md
+++ b/.github/instructions/github-workflow.instructions.md
@@ -265,6 +265,22 @@ Implement hero section with:
 7. After all issues done → Close milestone
 ```
 
+**⚠️ IMPORTANT: Auto-Close Only Works on Default Branch**
+
+GitHub only auto-closes issues (via "Closes #N", "Fixes #N") when PRs are merged to the **default branch** (`main`).
+
+When merging PRs to sprint branches (`week-*`), issues will **NOT** auto-close even if the commit message includes "Closes #N".
+
+**Always verify and manually close issues after merging to `week-*` branches:**
+
+```bash
+# After merging PR to week-N, check if issue is still open
+gh issue view NUMBER | cat
+
+# If still open, close manually with context
+gh issue close NUMBER --comment "Fixed in PR #XX (merged to week-N). Will be deployed with Week N release." | cat
+```
+
 ### Issue Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Documents the GitHub behavior where issues only auto-close when PRs merge to the default branch (`main`).

## Problem

When merging PRs to sprint branches (`week-*`), issues remain open even if the commit includes "Closes #N". This caused confusion with issue #123 which remained open after PR #124 was merged to `week-4`.

## Changes

Added to `.github/instructions/github-workflow.instructions.md`:
- Warning about auto-close only working on default branch
- Instructions to verify issue status after merge
- Example commands for manual closure with context

## Impact

This documentation helps prevent orphaned issues when following the GitFlow sprint workflow.