### PR TITLE
refactor: Use soma_get_stock_data() helper in StockDataEndpoint

### DIFF
--- a/wp-content/themes/soma/includes/API/Endpoints/StockDataEndpoint.php
+++ b/wp-content/themes/soma/includes/API/Endpoints/StockDataEndpoint.php
@@ -117,7 +117,7 @@ final class StockDataEndpoint {
 	 * @return WP_REST_Response|WP_Error Response data or error.
 	 */
 	private function handle( WP_REST_Request $_request ) {
-		$stock_data = get_option( 'stock_data' );
+		$stock_data = soma_get_stock_data();
 
 		if ( ! $stock_data ) {
 			return new WP_Error(


### PR DESCRIPTION
Small refactor to use the centralized helper function instead of direct `get_option()` call.

**Changes:**
- Replace `get_option('stock_data')` with `soma_get_stock_data()`

**Benefits:**
- Consistent with StockPrice widget pattern
- Centralized stock data access
- Better type safety (`?array` return type)