### PR TITLE
chore: Remove deprecated setAccessible() for PHP 8.1+

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -555,6 +555,30 @@ add_action( 'rest_api_init', $this->register(...) ); // ✅ Modern
 // NOT: add_action( 'rest_api_init', array( $this, 'register' ) ); // ❌ Old
 ```
 
+**ReflectionProperty (PHP 8.1+ - setAccessible() Deprecated):**
+In PHP 8.1+, `ReflectionProperty::setAccessible()` is deprecated and **no longer needed**. Private/protected properties are now accessible via `getValue()` and `setValue()` without calling `setAccessible(true)`.
+
+```php
+// ✅ CORRECT (PHP 8.1+)
+$reflection = new \ReflectionClass( ClassName::class );
+$property   = $reflection->getProperty( 'instance' );
+$property->setValue( null, null ); // Works without setAccessible()
+
+// ❌ DEPRECATED - Do NOT use
+$property->setAccessible( true ); // Deprecated in PHP 8.1+
+$property->setValue( null, null );
+```
+
+**Common use case - Reset singleton for testing:**
+```php
+private function reset_singleton( string $class_name ): void {
+    $reflection = new \ReflectionClass( $class_name );
+    $property   = $reflection->getProperty( 'instance' );
+    // Note: setAccessible() NOT needed in PHP 8.1+
+    $property->setValue( null, null );
+}
+```
+
 **LoadableInterface Pattern:**
 All module loaders must implement `Soma\Core\Interfaces\LoadableInterface`:
 - `init()`: Initialize the component

--- a/wp-content/themes/soma/tests/Integration/API/StockDataEndpointTest.php
+++ b/wp-content/themes/soma/tests/Integration/API/StockDataEndpointTest.php
@@ -1,0 +1,406 @@
+<?php
+/**
+ * StockDataEndpoint Integration Tests
+ *
+ * Tests the REST API endpoint /soma/stock-data with real data.
+ *
+ * @package Soma
+ * @subpackage Tests\Integration\API
+ */
+
+namespace Soma\Tests\Integration\API;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use WP_UnitTestCase;
+use Soma\Admin\StockData;
+use Soma\API\Endpoints\StockDataEndpoint;
+
+/**
+ * Test StockDataEndpoint REST API
+ *
+ * @group integration
+ * @group api
+ * @group rest-api
+ * @group stock-data
+ */
+class StockDataEndpointTest extends WP_UnitTestCase {
+
+	/**
+	 * REST server instance.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Initialize REST API server.
+		global $wp_rest_server;
+		$this->server = $wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init' );
+
+		// Clean up stock data option.
+		delete_option( 'stock_data' );
+
+		// Reset singleton instances for fresh tests.
+		$this->reset_singleton( StockData::class );
+		$this->reset_singleton( StockDataEndpoint::class );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		delete_option( 'stock_data' );
+
+		// Unschedule cron event.
+		$timestamp = wp_next_scheduled( 'update_stock_data_event' );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, 'update_stock_data_event' );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Reset singleton instance via reflection.
+	 *
+	 * Note: In PHP 8.1+, setAccessible() is no longer needed for ReflectionProperty.
+	 *
+	 * @param string $class_name Fully qualified class name.
+	 */
+	private function reset_singleton( string $class_name ): void {
+		$reflection = new \ReflectionClass( $class_name );
+		$property   = $reflection->getProperty( 'instance' );
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Test REST route is registered.
+	 */
+	public function test_rest_route_is_registered(): void {
+		StockDataEndpoint::instance();
+
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( '/soma/stock-data', $routes );
+	}
+
+	/**
+	 * Test endpoint supports GET method.
+	 *
+	 * WordPress REST API stores methods as associative array with method names as keys.
+	 */
+	public function test_endpoint_supports_get_method(): void {
+		StockDataEndpoint::instance();
+
+		$routes = $this->server->get_routes();
+		$route  = $routes['/soma/stock-data'][0];
+
+		// WordPress REST API stores methods as ['GET' => true, ...].
+		$this->assertArrayHasKey( 'GET', $route['methods'] );
+		$this->assertTrue( $route['methods']['GET'] );
+	}
+
+	/**
+	 * Test endpoint returns 404 when no stock data exists.
+	 */
+	public function test_endpoint_returns_404_when_no_data(): void {
+		StockDataEndpoint::instance();
+		delete_option( 'stock_data' );
+
+		$request  = new WP_REST_Request( 'GET', '/soma/stock-data' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'no_data', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Test endpoint returns 200 when stock data exists.
+	 */
+	public function test_endpoint_returns_200_when_data_exists(): void {
+		StockDataEndpoint::instance();
+
+		$test_data = array(
+			'price'                  => 50.0,
+			'volume'                 => 400,
+			'change'                 => 0.0,
+			'percent'                => 0.0,
+			'exchangeTimezoneName'   => 'America/Mexico_City',
+			'exchangeTimezoneOffset' => -21600000,
+			'symbol'                 => 'SOMA21.MX',
+			'timestamp'              => 1767373811,
+			'currency'               => 'MXN',
+			'shortName'              => 'CIBANCO SA INSTIT DE BANCA MULT',
+			'longName'               => 'Fibra SOMA',
+			'marketState'            => 'CLOSED',
+		);
+		update_option( 'stock_data', $test_data );
+
+		$request  = new WP_REST_Request( 'GET', '/soma/stock-data' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test endpoint returns correct data structure.
+	 */
+	public function test_endpoint_returns_correct_data_structure(): void {
+		StockDataEndpoint::instance();
+
+		$test_data = array(
+			'price'                  => 50.0,
+			'volume'                 => 400,
+			'change'                 => 0.5,
+			'percent'                => 1.0,
+			'exchangeTimezoneName'   => 'America/Mexico_City',
+			'exchangeTimezoneOffset' => -21600000,
+			'symbol'                 => 'SOMA21.MX',
+			'timestamp'              => 1767373811,
+			'currency'               => 'MXN',
+			'shortName'              => 'CIBANCO SA INSTIT DE BANCA MULT',
+			'longName'               => 'Fibra SOMA',
+			'marketState'            => 'CLOSED',
+		);
+		update_option( 'stock_data', $test_data );
+
+		$request  = new WP_REST_Request( 'GET', '/soma/stock-data' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Verify all required fields exist.
+		$this->assertArrayHasKey( 'price', $data );
+		$this->assertArrayHasKey( 'volume', $data );
+		$this->assertArrayHasKey( 'change', $data );
+		$this->assertArrayHasKey( 'percent', $data );
+		$this->assertArrayHasKey( 'symbol', $data );
+		$this->assertArrayHasKey( 'currency', $data );
+		$this->assertArrayHasKey( 'timestamp', $data );
+		$this->assertArrayHasKey( 'marketState', $data );
+		$this->assertArrayHasKey( 'exchangeTimezoneName', $data );
+		$this->assertArrayHasKey( 'exchangeTimezoneOffset', $data );
+		$this->assertArrayHasKey( 'shortName', $data );
+		$this->assertArrayHasKey( 'longName', $data );
+	}
+
+	/**
+	 * Test endpoint returns correct values.
+	 */
+	public function test_endpoint_returns_correct_values(): void {
+		StockDataEndpoint::instance();
+
+		$test_data = array(
+			'price'                  => 50.0,
+			'volume'                 => 400,
+			'change'                 => 0.5,
+			'percent'                => 1.0,
+			'exchangeTimezoneName'   => 'America/Mexico_City',
+			'exchangeTimezoneOffset' => -21600000,
+			'symbol'                 => 'SOMA21.MX',
+			'timestamp'              => 1767373811,
+			'currency'               => 'MXN',
+			'shortName'              => 'CIBANCO SA INSTIT DE BANCA MULT',
+			'longName'               => 'Fibra SOMA',
+			'marketState'            => 'CLOSED',
+		);
+		update_option( 'stock_data', $test_data );
+
+		$request  = new WP_REST_Request( 'GET', '/soma/stock-data' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 50.0, $data['price'] );
+		$this->assertSame( 400, $data['volume'] );
+		$this->assertSame( 'SOMA21.MX', $data['symbol'] );
+		$this->assertSame( 'MXN', $data['currency'] );
+		$this->assertSame( 'Fibra SOMA', $data['longName'] );
+		$this->assertSame( 'America/Mexico_City', $data['exchangeTimezoneName'] );
+		$this->assertSame( 'CLOSED', $data['marketState'] );
+	}
+
+	/**
+	 * Test endpoint returns real API data after fetch.
+	 *
+	 * @group slow
+	 * @group external-api
+	 */
+	public function test_endpoint_returns_real_api_data(): void {
+		StockDataEndpoint::instance();
+
+		// Fetch real data from Yahoo Finance.
+		$stock_instance = StockData::instance();
+		$stock_instance->fetch_stock_data();
+
+		$request  = new WP_REST_Request( 'GET', '/soma/stock-data' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Should return 200 with real data.
+		$this->assertSame( 200, $response->get_status() );
+
+		// Verify real data values.
+		$this->assertSame( 'SOMA21.MX', $data['symbol'] );
+		$this->assertSame( 'MXN', $data['currency'] );
+		$this->assertSame( 'Fibra SOMA', $data['longName'] );
+		$this->assertSame( 'America/Mexico_City', $data['exchangeTimezoneName'] );
+
+		// Verify price is in expected range (52-week: $44-$55).
+		$this->assertGreaterThanOrEqual( 40.0, $data['price'] );
+		$this->assertLessThanOrEqual( 60.0, $data['price'] );
+
+		// Verify numeric types.
+		$this->assertIsNumeric( $data['price'] );
+		$this->assertIsInt( $data['volume'] );
+		$this->assertIsNumeric( $data['change'] );
+		$this->assertIsNumeric( $data['percent'] );
+	}
+
+	/**
+	 * Test endpoint is publicly accessible (no auth required).
+	 */
+	public function test_endpoint_is_publicly_accessible(): void {
+		StockDataEndpoint::instance();
+
+		$test_data = array(
+			'price'    => 50.0,
+			'symbol'   => 'SOMA21.MX',
+			'currency' => 'MXN',
+		);
+		update_option( 'stock_data', $test_data );
+
+		// Ensure we're not logged in.
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'GET', '/soma/stock-data' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test endpoint does not support POST method.
+	 */
+	public function test_endpoint_does_not_support_post(): void {
+		StockDataEndpoint::instance();
+
+		$request  = new WP_REST_Request( 'POST', '/soma/stock-data' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test endpoint does not support PUT method.
+	 */
+	public function test_endpoint_does_not_support_put(): void {
+		StockDataEndpoint::instance();
+
+		$request  = new WP_REST_Request( 'PUT', '/soma/stock-data' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test endpoint does not support DELETE method.
+	 */
+	public function test_endpoint_does_not_support_delete(): void {
+		StockDataEndpoint::instance();
+
+		$request  = new WP_REST_Request( 'DELETE', '/soma/stock-data' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test response content type is JSON.
+	 */
+	public function test_response_content_type_is_json(): void {
+		StockDataEndpoint::instance();
+
+		$test_data = array(
+			'price'    => 50.0,
+			'symbol'   => 'SOMA21.MX',
+			'currency' => 'MXN',
+		);
+		update_option( 'stock_data', $test_data );
+
+		$request  = new WP_REST_Request( 'GET', '/soma/stock-data' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+	}
+
+	/**
+	 * Test real API data timestamp is recent.
+	 *
+	 * @group slow
+	 * @group external-api
+	 */
+	public function test_real_api_timestamp_is_recent(): void {
+		StockDataEndpoint::instance();
+
+		// Fetch real data.
+		$stock_instance = StockData::instance();
+		$stock_instance->fetch_stock_data();
+
+		$request  = new WP_REST_Request( 'GET', '/soma/stock-data' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Timestamp should be within the last 7 days (markets may be closed).
+		$seven_days_ago = time() - ( 7 * DAY_IN_SECONDS );
+		$this->assertGreaterThan( $seven_days_ago, $data['timestamp'] );
+	}
+
+	/**
+	 * Test real API market state is valid.
+	 *
+	 * @group slow
+	 * @group external-api
+	 */
+	public function test_real_api_market_state_is_valid(): void {
+		StockDataEndpoint::instance();
+
+		// Fetch real data.
+		$stock_instance = StockData::instance();
+		$stock_instance->fetch_stock_data();
+
+		$request  = new WP_REST_Request( 'GET', '/soma/stock-data' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$valid_states = array( 'CLOSED', 'REGULAR', 'PRE', 'POST', 'PREPRE', 'POSTPOST' );
+		$this->assertContains( $data['marketState'], $valid_states );
+	}
+
+	/**
+	 * Test real API exchange timezone offset.
+	 *
+	 * @group slow
+	 * @group external-api
+	 */
+	public function test_real_api_timezone_offset(): void {
+		StockDataEndpoint::instance();
+
+		// Fetch real data.
+		$stock_instance = StockData::instance();
+		$stock_instance->fetch_stock_data();
+
+		$request  = new WP_REST_Request( 'GET', '/soma/stock-data' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Mexico City is UTC-6 = -21600000 milliseconds.
+		$this->assertSame( -21600000, $data['exchangeTimezoneOffset'] );
+	}
+}

--- a/wp-content/themes/soma/tests/Integration/Admin/StockDataTest.php
+++ b/wp-content/themes/soma/tests/Integration/Admin/StockDataTest.php
@@ -1,0 +1,570 @@
+<?php
+/**
+ * StockData Integration Tests
+ *
+ * Tests the StockData class functionality with real WordPress environment
+ * and real Yahoo Finance API calls.
+ *
+ * @package Soma
+ * @subpackage Tests\Integration\Admin
+ */
+
+namespace Soma\Tests\Integration\Admin;
+
+use WP_UnitTestCase;
+use Soma\Admin\StockData;
+
+/**
+ * Test StockData class integration with WordPress and Yahoo Finance API
+ *
+ * @group integration
+ * @group admin
+ * @group stock-data
+ * @group api
+ */
+class StockDataTest extends WP_UnitTestCase {
+
+	/**
+	 * Clean up stock data option before each test
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		delete_option( 'stock_data' );
+
+		// Reset singleton instance for fresh tests.
+		// Note: In PHP 8.1+, setAccessible() is no longer needed for ReflectionProperty.
+		$reflection = new \ReflectionClass( StockData::class );
+		$property   = $reflection->getProperty( 'instance' );
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Clean up after each test
+	 */
+	public function tearDown(): void {
+		delete_option( 'stock_data' );
+
+		// Unschedule cron event.
+		$timestamp = wp_next_scheduled( 'update_stock_data_event' );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, 'update_stock_data_event' );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test singleton returns same instance
+	 */
+	public function test_singleton_returns_same_instance(): void {
+		$instance1 = StockData::instance();
+		$instance2 = StockData::instance();
+
+		$this->assertSame( $instance1, $instance2 );
+	}
+
+	/**
+	 * Test cron schedule is registered
+	 */
+	public function test_cron_schedule_is_registered(): void {
+		StockData::instance();
+
+		$schedules = wp_get_schedules();
+
+		$this->assertArrayHasKey( 'three_hours', $schedules );
+		$this->assertSame( 3 * HOUR_IN_SECONDS, $schedules['three_hours']['interval'] );
+	}
+
+	/**
+	 * Test cron event is scheduled
+	 */
+	public function test_cron_event_is_scheduled(): void {
+		StockData::instance();
+
+		$next_scheduled = wp_next_scheduled( 'update_stock_data_event' );
+
+		$this->assertNotFalse( $next_scheduled );
+		$this->assertGreaterThan( 0, $next_scheduled );
+	}
+
+	/**
+	 * Test custom_cron_schedules adds three_hours interval
+	 */
+	public function test_custom_cron_schedules_adds_interval(): void {
+		$instance  = StockData::instance();
+		$schedules = $instance->custom_cron_schedules( array() );
+
+		$this->assertArrayHasKey( 'three_hours', $schedules );
+		$this->assertSame( 3 * HOUR_IN_SECONDS, $schedules['three_hours']['interval'] );
+		$this->assertArrayHasKey( 'display', $schedules['three_hours'] );
+	}
+
+	/**
+	 * Test custom_cron_schedules preserves existing schedules
+	 */
+	public function test_custom_cron_schedules_preserves_existing(): void {
+		$instance  = StockData::instance();
+		$existing  = array(
+			'daily' => array(
+				'interval' => DAY_IN_SECONDS,
+				'display'  => 'Once Daily',
+			),
+		);
+		$schedules = $instance->custom_cron_schedules( $existing );
+
+		$this->assertArrayHasKey( 'daily', $schedules );
+		$this->assertArrayHasKey( 'three_hours', $schedules );
+	}
+
+	/**
+	 * Test get_stock_data returns null when no data exists
+	 */
+	public function test_get_stock_data_returns_null_when_empty(): void {
+		delete_option( 'stock_data' );
+
+		$data = StockData::get_stock_data();
+
+		$this->assertNull( $data );
+	}
+
+	/**
+	 * Test get_stock_data returns array when data exists
+	 */
+	public function test_get_stock_data_returns_array_when_exists(): void {
+		$test_data = array(
+			'price'    => 50.0,
+			'currency' => 'MXN',
+			'symbol'   => 'SOMA21.MX',
+		);
+		update_option( 'stock_data', $test_data );
+
+		$data = StockData::get_stock_data();
+
+		$this->assertIsArray( $data );
+		$this->assertSame( 50.0, $data['price'] );
+		$this->assertSame( 'MXN', $data['currency'] );
+		$this->assertSame( 'SOMA21.MX', $data['symbol'] );
+	}
+
+	/**
+	 * Test get_stock_data returns null for non-array option
+	 */
+	public function test_get_stock_data_returns_null_for_non_array(): void {
+		update_option( 'stock_data', 'invalid string' );
+
+		$data = StockData::get_stock_data();
+
+		$this->assertNull( $data );
+	}
+
+	/**
+	 * Test fetch_stock_data makes real API call and stores data
+	 *
+	 * This test uses the real Yahoo Finance API with SOMA21.MX symbol.
+	 * Expected data structure based on actual API response:
+	 * - price: ~50.0 MXN
+	 * - symbol: SOMA21.MX
+	 * - currency: MXN
+	 * - marketState: CLOSED or REGULAR
+	 * - exchangeTimezoneName: America/Mexico_City
+	 *
+	 * @group slow
+	 * @group external-api
+	 */
+	public function test_fetch_stock_data_stores_real_data(): void {
+		$instance = StockData::instance();
+
+		// Execute the fetch.
+		$instance->fetch_stock_data();
+
+		// Get the stored data.
+		$data = get_option( 'stock_data' );
+
+		// Verify data was stored.
+		$this->assertIsArray( $data, 'Stock data should be stored as array' );
+
+		// Verify required fields exist.
+		$required_fields = array(
+			'price',
+			'volume',
+			'change',
+			'percent',
+			'symbol',
+			'timestamp',
+			'currency',
+			'marketState',
+		);
+
+		foreach ( $required_fields as $field ) {
+			$this->assertArrayHasKey( $field, $data, "Stock data should have '{$field}' field" );
+		}
+
+		// Verify symbol is correct.
+		$this->assertSame( 'SOMA21.MX', $data['symbol'] );
+
+		// Verify currency is MXN.
+		$this->assertSame( 'MXN', $data['currency'] );
+
+		// Verify price is a valid number.
+		$this->assertIsNumeric( $data['price'] );
+		$this->assertGreaterThan( 0, $data['price'], 'Price should be positive' );
+
+		// Verify timestamp is a valid Unix timestamp.
+		$this->assertIsInt( $data['timestamp'] );
+		$this->assertGreaterThan( 0, $data['timestamp'] );
+
+		// Verify market state is valid.
+		$valid_states = array( 'CLOSED', 'REGULAR', 'PRE', 'POST', 'PREPRE', 'POSTPOST' );
+		$this->assertContains( $data['marketState'], $valid_states );
+	}
+
+	/**
+	 * Test fetch_stock_data price is within expected range
+	 *
+	 * Based on actual 52-week range: $44.00 - $55.00 MXN.
+	 *
+	 * @group slow
+	 * @group external-api
+	 */
+	public function test_fetch_stock_data_price_in_expected_range(): void {
+		$instance = StockData::instance();
+		$instance->fetch_stock_data();
+
+		$data = get_option( 'stock_data' );
+
+		// Price should be within 52-week range (with some buffer).
+		$this->assertGreaterThanOrEqual( 40.0, $data['price'], 'Price should be >= $40 MXN' );
+		$this->assertLessThanOrEqual( 60.0, $data['price'], 'Price should be <= $60 MXN' );
+	}
+
+	/**
+	 * Test fetch_stock_data includes exchange timezone info
+	 *
+	 * @group slow
+	 * @group external-api
+	 */
+	public function test_fetch_stock_data_includes_timezone_info(): void {
+		$instance = StockData::instance();
+		$instance->fetch_stock_data();
+
+		$data = get_option( 'stock_data' );
+
+		// Verify timezone fields exist.
+		$this->assertArrayHasKey( 'exchangeTimezoneName', $data );
+		$this->assertArrayHasKey( 'exchangeTimezoneOffset', $data );
+
+		// Verify Mexico City timezone.
+		$this->assertSame( 'America/Mexico_City', $data['exchangeTimezoneName'] );
+	}
+
+	/**
+	 * Test fetch_stock_data includes company name info
+	 *
+	 * @group slow
+	 * @group external-api
+	 */
+	public function test_fetch_stock_data_includes_company_info(): void {
+		$instance = StockData::instance();
+		$instance->fetch_stock_data();
+
+		$data = get_option( 'stock_data' );
+
+		// Verify company name fields exist.
+		$this->assertArrayHasKey( 'shortName', $data );
+		$this->assertArrayHasKey( 'longName', $data );
+
+		// longName should be "Fibra SOMA".
+		$this->assertSame( 'Fibra SOMA', $data['longName'] );
+	}
+
+	/**
+	 * Test soma_get_stock_data helper function works
+	 *
+	 * @group slow
+	 * @group external-api
+	 */
+	public function test_helper_function_returns_data(): void {
+		$instance = StockData::instance();
+		$instance->fetch_stock_data();
+
+		// Use the helper function.
+		$data = soma_get_stock_data();
+
+		$this->assertIsArray( $data );
+		$this->assertSame( 'SOMA21.MX', $data['symbol'] );
+		$this->assertSame( 'MXN', $data['currency'] );
+	}
+
+	/**
+	 * Test soma_get_stock_data returns null when no data
+	 */
+	public function test_helper_function_returns_null_when_empty(): void {
+		delete_option( 'stock_data' );
+
+		$data = soma_get_stock_data();
+
+		$this->assertNull( $data );
+	}
+
+	/**
+	 * Test fetch does not schedule duplicate cron events
+	 */
+	public function test_does_not_duplicate_cron_events(): void {
+		// Initialize twice.
+		StockData::instance();
+
+		// Reset and initialize again.
+		// Note: In PHP 8.1+, setAccessible() is no longer needed for ReflectionProperty.
+		$reflection = new \ReflectionClass( StockData::class );
+		$property   = $reflection->getProperty( 'instance' );
+		$property->setValue( null, null );
+
+		StockData::instance();
+
+		// Get all scheduled events for this hook.
+		$cron = _get_cron_array();
+		$count = 0;
+
+		foreach ( $cron as $timestamp => $hooks ) {
+			if ( isset( $hooks['update_stock_data_event'] ) ) {
+				++$count;
+			}
+		}
+
+		$this->assertSame( 1, $count, 'Should only have one scheduled event' );
+	}
+
+	/**
+	 * Test cron interval is 3 hours (10800 seconds)
+	 */
+	public function test_cron_interval_is_three_hours(): void {
+		StockData::instance();
+
+		$schedules = wp_get_schedules();
+
+		$this->assertSame( 10800, $schedules['three_hours']['interval'] );
+	}
+
+	/**
+	 * Test cron event uses correct recurrence schedule
+	 */
+	public function test_cron_event_uses_three_hours_schedule(): void {
+		StockData::instance();
+
+		$cron      = _get_cron_array();
+		$recurrence = null;
+
+		foreach ( $cron as $timestamp => $hooks ) {
+			if ( isset( $hooks['update_stock_data_event'] ) ) {
+				$recurrence = $hooks['update_stock_data_event'][ key( $hooks['update_stock_data_event'] ) ]['schedule'];
+				break;
+			}
+		}
+
+		$this->assertSame( 'three_hours', $recurrence );
+	}
+
+	/**
+	 * Test cron event first run is in the future
+	 */
+	public function test_cron_first_run_is_in_future(): void {
+		StockData::instance();
+
+		$next_scheduled = wp_next_scheduled( 'update_stock_data_event' );
+		$now            = current_time( 'timestamp' );
+
+		$this->assertGreaterThanOrEqual( $now, $next_scheduled );
+	}
+
+	/**
+	 * Test cron event first run is within 3 hours
+	 */
+	public function test_cron_first_run_within_three_hours(): void {
+		StockData::instance();
+
+		$next_scheduled = wp_next_scheduled( 'update_stock_data_event' );
+		$now            = current_time( 'timestamp' );
+		$three_hours    = 3 * HOUR_IN_SECONDS;
+
+		$this->assertLessThanOrEqual( $now + $three_hours, $next_scheduled );
+	}
+
+	/**
+	 * Test cron schedule filter is properly hooked
+	 */
+	public function test_cron_schedule_filter_is_hooked(): void {
+		StockData::instance();
+
+		$this->assertGreaterThan(
+			0,
+			has_filter( 'cron_schedules', array( StockData::instance(), 'custom_cron_schedules' ) )
+		);
+	}
+
+	/**
+	 * Test cron action is properly hooked
+	 */
+	public function test_cron_action_is_hooked(): void {
+		StockData::instance();
+
+		$this->assertGreaterThan(
+			0,
+			has_action( 'update_stock_data_event', array( StockData::instance(), 'fetch_stock_data' ) )
+		);
+	}
+
+	/**
+	 * Test manual cron execution fetches data
+	 *
+	 * @group slow
+	 * @group external-api
+	 */
+	public function test_manual_cron_execution_fetches_data(): void {
+		StockData::instance();
+
+		// Manually trigger the cron action.
+		do_action( 'update_stock_data_event' );
+
+		// Verify data was fetched.
+		$data = get_option( 'stock_data' );
+
+		$this->assertIsArray( $data );
+		$this->assertSame( 'SOMA21.MX', $data['symbol'] );
+		$this->assertSame( 'MXN', $data['currency'] );
+	}
+
+	/**
+	 * Test cron schedule registered before event
+	 *
+	 * This test validates the fix from commit 30911d8.
+	 * The cron schedule must be registered BEFORE wp_schedule_event() is called.
+	 */
+	public function test_cron_schedule_registered_before_event(): void {
+		// Reset singleton.
+		// Note: In PHP 8.1+, setAccessible() is no longer needed for ReflectionProperty.
+		$reflection = new \ReflectionClass( StockData::class );
+		$property   = $reflection->getProperty( 'instance' );
+		$property->setValue( null, null );
+
+		// Remove all existing schedules and events.
+		remove_all_filters( 'cron_schedules' );
+		$timestamp = wp_next_scheduled( 'update_stock_data_event' );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, 'update_stock_data_event' );
+		}
+
+		// Initialize the singleton (this should register schedule first, then event).
+		StockData::instance();
+
+		// Verify schedule exists.
+		$schedules = wp_get_schedules();
+		$this->assertArrayHasKey( 'three_hours', $schedules );
+
+		// Verify event is scheduled with the correct recurrence.
+		$cron       = _get_cron_array();
+		$found      = false;
+		$recurrence = null;
+
+		foreach ( $cron as $ts => $hooks ) {
+			if ( isset( $hooks['update_stock_data_event'] ) ) {
+				$found      = true;
+				$recurrence = $hooks['update_stock_data_event'][ key( $hooks['update_stock_data_event'] ) ]['schedule'];
+				break;
+			}
+		}
+
+		$this->assertTrue( $found, 'Cron event should be scheduled' );
+		$this->assertSame( 'three_hours', $recurrence, 'Cron should use three_hours schedule' );
+	}
+
+	/**
+	 * Test fetch_stock_data updates existing data
+	 *
+	 * @group slow
+	 * @group external-api
+	 */
+	public function test_fetch_updates_existing_data(): void {
+		// Set initial data.
+		$initial_data = array(
+			'price'     => 0,
+			'symbol'    => 'OLD',
+			'currency'  => 'USD',
+			'timestamp' => 0,
+		);
+		update_option( 'stock_data', $initial_data );
+
+		// Fetch new data.
+		$instance = StockData::instance();
+		$instance->fetch_stock_data();
+
+		// Get updated data.
+		$data = get_option( 'stock_data' );
+
+		// Verify data was updated.
+		$this->assertSame( 'SOMA21.MX', $data['symbol'] );
+		$this->assertSame( 'MXN', $data['currency'] );
+		$this->assertGreaterThan( 0, $data['price'] );
+		$this->assertGreaterThan( 0, $data['timestamp'] );
+	}
+
+	/**
+	 * Test multiple fetch calls update data correctly
+	 *
+	 * @group slow
+	 * @group external-api
+	 */
+	public function test_multiple_fetches_update_correctly(): void {
+		$instance = StockData::instance();
+
+		// First fetch.
+		$instance->fetch_stock_data();
+		$first_data = get_option( 'stock_data' );
+
+		// Second fetch.
+		$instance->fetch_stock_data();
+		$second_data = get_option( 'stock_data' );
+
+		// Both should have valid data.
+		$this->assertSame( 'SOMA21.MX', $first_data['symbol'] );
+		$this->assertSame( 'SOMA21.MX', $second_data['symbol'] );
+		$this->assertSame( $first_data['currency'], $second_data['currency'] );
+	}
+
+	/**
+	 * Test stored data matches expected API response format
+	 *
+	 * Based on real Yahoo Finance API response for SOMA21.MX.
+	 *
+	 * @group slow
+	 * @group external-api
+	 */
+	public function test_stored_data_matches_api_format(): void {
+		$instance = StockData::instance();
+		$instance->fetch_stock_data();
+
+		$data = get_option( 'stock_data' );
+
+		// Verify exact field mapping from API response.
+		$expected_fields = array(
+			'price'                  => 'regularMarketPrice',
+			'volume'                 => 'regularMarketVolume',
+			'change'                 => 'regularMarketChange',
+			'percent'                => 'regularMarketChangePercent',
+			'exchangeTimezoneName'   => 'exchangeTimezoneName',
+			'exchangeTimezoneOffset' => 'gmtOffSetMilliseconds',
+			'symbol'                 => 'symbol',
+			'timestamp'              => 'regularMarketTime',
+			'currency'               => 'currency',
+			'shortName'              => 'shortName',
+			'longName'               => 'longName',
+			'marketState'            => 'marketState',
+		);
+
+		foreach ( array_keys( $expected_fields ) as $field ) {
+			$this->assertArrayHasKey( $field, $data, "Missing field: {$field}" );
+		}
+
+		// Verify count matches.
+		$this->assertCount( 12, $data, 'Data should have exactly 12 fields' );
+	}
+}

--- a/wp-content/themes/soma/tests/Unit/Admin/StockDataTest.php
+++ b/wp-content/themes/soma/tests/Unit/Admin/StockDataTest.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * StockData Unit Tests
+ *
+ * Tests the StockData class that fetches and caches stock market data
+ * from Yahoo Finance API.
+ *
+ * @package Soma
+ * @subpackage Tests\Unit\Admin
+ */
+
+namespace Soma\Tests\Unit\Admin;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Test StockData class structure and methods
+ *
+ * @group unit
+ * @group admin
+ * @group stock-data
+ */
+class StockDataTest extends TestCase {
+
+	/**
+	 * The StockData class name
+	 *
+	 * @var string
+	 */
+	private string $class_name = \Soma\Admin\StockData::class;
+
+	/**
+	 * Test class exists
+	 */
+	public function test_class_exists(): void {
+		$this->assertTrue( class_exists( $this->class_name ) );
+	}
+
+	/**
+	 * Test singleton pattern - instance method exists
+	 */
+	public function test_has_instance_method(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$this->assertTrue( $reflection->hasMethod( 'instance' ) );
+	}
+
+	/**
+	 * Test singleton pattern - instance method is static
+	 */
+	public function test_instance_method_is_static(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$method     = $reflection->getMethod( 'instance' );
+		$this->assertTrue( $method->isStatic() );
+	}
+
+	/**
+	 * Test singleton pattern - instance method is public
+	 */
+	public function test_instance_method_is_public(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$method     = $reflection->getMethod( 'instance' );
+		$this->assertTrue( $method->isPublic() );
+	}
+
+	/**
+	 * Test constructor is private (singleton pattern)
+	 */
+	public function test_constructor_is_private(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$constructor = $reflection->getConstructor();
+		$this->assertTrue( $constructor->isPrivate() );
+	}
+
+	/**
+	 * Test clone method is private (singleton pattern)
+	 */
+	public function test_clone_is_private(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$method     = $reflection->getMethod( '__clone' );
+		$this->assertTrue( $method->isPrivate() );
+	}
+
+	/**
+	 * Test has get_stock_data method
+	 */
+	public function test_has_get_stock_data_method(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$this->assertTrue( $reflection->hasMethod( 'get_stock_data' ) );
+	}
+
+	/**
+	 * Test get_stock_data is static
+	 */
+	public function test_get_stock_data_is_static(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$method     = $reflection->getMethod( 'get_stock_data' );
+		$this->assertTrue( $method->isStatic() );
+	}
+
+	/**
+	 * Test has fetch_stock_data method
+	 */
+	public function test_has_fetch_stock_data_method(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$this->assertTrue( $reflection->hasMethod( 'fetch_stock_data' ) );
+	}
+
+	/**
+	 * Test has custom_cron_schedules method
+	 */
+	public function test_has_custom_cron_schedules_method(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$this->assertTrue( $reflection->hasMethod( 'custom_cron_schedules' ) );
+	}
+
+	/**
+	 * Test has init method
+	 */
+	public function test_has_init_method(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$this->assertTrue( $reflection->hasMethod( 'init' ) );
+	}
+
+	/**
+	 * Test init method is private
+	 */
+	public function test_init_is_private(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$method     = $reflection->getMethod( 'init' );
+		$this->assertTrue( $method->isPrivate() );
+	}
+
+	/**
+	 * Test has symbol property
+	 */
+	public function test_has_symbol_property(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$this->assertTrue( $reflection->hasProperty( 'symbol' ) );
+	}
+
+	/**
+	 * Test symbol property default value.
+	 *
+	 * Note: In PHP 8.1+, setAccessible() is no longer needed for ReflectionProperty.
+	 */
+	public function test_symbol_default_value(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+
+		// Get default value from property definition.
+		$defaults = $reflection->getDefaultProperties();
+		$this->assertSame( 'SOMA21.MX', $defaults['symbol'] );
+	}
+
+	/**
+	 * Test has api_endpoint property
+	 */
+	public function test_has_api_endpoint_property(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$this->assertTrue( $reflection->hasProperty( 'api_endpoint' ) );
+	}
+
+	/**
+	 * Test api_endpoint uses Yahoo Finance RapidAPI
+	 */
+	public function test_api_endpoint_is_yahoo_finance(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$defaults   = $reflection->getDefaultProperties();
+		$this->assertStringContainsString( 'yahoo-finance', $defaults['api_endpoint'] );
+		$this->assertStringContainsString( 'rapidapi', $defaults['api_endpoint'] );
+	}
+
+	/**
+	 * Test has api_key property
+	 */
+	public function test_has_api_key_property(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$this->assertTrue( $reflection->hasProperty( 'api_key' ) );
+	}
+
+	/**
+	 * Test has api_host property
+	 */
+	public function test_has_api_host_property(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$this->assertTrue( $reflection->hasProperty( 'api_host' ) );
+	}
+
+	/**
+	 * Test api_host matches endpoint domain
+	 */
+	public function test_api_host_matches_endpoint(): void {
+		$reflection = new ReflectionClass( $this->class_name );
+		$defaults   = $reflection->getDefaultProperties();
+		$this->assertStringContainsString( $defaults['api_host'], $defaults['api_endpoint'] );
+	}
+}


### PR DESCRIPTION
## Description

Remove deprecated `setAccessible()` calls from test files for PHP 8.1+ compatibility.

## Changes

- Remove `setAccessible(true)` from StockData test files (5 occurrences)
- Add PHP 8.1+ ReflectionProperty documentation to copilot-instructions.md

## Rationale

In PHP 8.1+, `ReflectionProperty::setAccessible()` is deprecated and no longer needed. Private/protected properties are now accessible via `getValue()` and `setValue()` without calling `setAccessible(true)`.

## Files Modified

- `tests/Integration/Admin/StockDataTest.php`
- `tests/Integration/API/StockDataEndpointTest.php`  
- `tests/Unit/Admin/StockDataTest.php`
- `.github/copilot-instructions.md`

## Testing

- ✅ All 41 StockData tests pass (26 integration + 15 endpoint tests)
- ✅ No deprecated warnings

## Checklist

- [x] Code follows WordPress Coding Standards
- [x] Tests pass
- [x] Documentation updated