### PR TITLE
chore: Prepare release v3.1.11

### DIFF
--- a/wp-content/themes/soma/CHANGELOG.md
+++ b/wp-content/themes/soma/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [3.1.11] - 2025-01-06
+
+### Week 4 Patch - JavaScript & Footer Bug Fixes
+
+This patch release fixes the stock price display issue on the company page and resolves HTML tags being visible in the mobile footer.
+
+---
+
 ### 🐛 Fixed
 
 #### JavaScript Execution
@@ -21,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **HTML Tags Visible on Mobile** - Fixed `<br>` tags showing as literal text instead of rendering (#159)
   - Changed `logo_subtext` from `esc_html()` to `wp_kses_post()` to allow safe HTML
   - Changed `copyright` from `esc_html()` to `wp_kses_post()` for consistency with Elementor widget
+
+---
+
+### 🔗 Related Issues & PRs
+
+- **PR #160**: [fix: Prevent Slick carousel crash from blocking ShareQuotation](https://github.com/sanruiz/fibra/pull/160) - Merged
+- **PR #161**: [fix: Footer <br> tags visible on mobile](https://github.com/sanruiz/fibra/pull/161) - Merged
 
 ---
 

--- a/wp-content/themes/soma/style.css
+++ b/wp-content/themes/soma/style.css
@@ -4,5 +4,5 @@ Theme URI: https://github.com/sanruiz/fibra
 Description: Modern WordPress theme with PSR-4 architecture, ACF flexible content, and Elementor integration.
 Author: Santiago Ramirez
 Author URI: https://github.com/sanruiz
-Version: 3.1.10
+Version: 3.1.11
 */


### PR DESCRIPTION
## Release v3.1.11

### Changes
- Updated version from 3.1.10 to 3.1.11 in style.css
- Converted [Unreleased] to [3.1.11] in CHANGELOG.md

### Fixes Included
- **#158** - ShareQuotation stock price showing $0 on company page
- **#159** - Footer `<br>` tags visible on mobile

### Release Checklist
- [x] Version bumped in style.css
- [x] CHANGELOG.md updated with release notes
- [ ] CI checks pass
- [ ] Merge to week-4
- [ ] Create PR from week-4 to main
- [ ] Merge to main
- [ ] Create and push tag v3.1.11