### PR TITLE
chore: Release v3.1.12

### DIFF
--- a/wp-content/themes/soma/CHANGELOG.md
+++ b/wp-content/themes/soma/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [3.1.12] - 2026-01-08
+
 ### Week 4 Feature - TeamMember Elementor Widget
 
 This release adds a new TeamMember Elementor widget that replicates the team member single page functionality, enabling flexible integration of team member profiles into any page layout via Elementor.
@@ -48,6 +52,12 @@ This release adds a new TeamMember Elementor widget that replicates the team mem
 
 #### Modified
 - `wp-content/themes/soma/CHANGELOG.md` - Version documentation
+
+---
+
+### 🔗 Related Issues & PRs
+
+- **PR #164**: [feat(elementor): Add TeamMember widget](https://github.com/sanruiz/fibra/pull/164) - Merged to week-4
 
 ---
 

--- a/wp-content/themes/soma/style.css
+++ b/wp-content/themes/soma/style.css
@@ -4,5 +4,5 @@ Theme URI: https://github.com/sanruiz/fibra
 Description: Modern WordPress theme with PSR-4 architecture, ACF flexible content, and Elementor integration.
 Author: Santiago Ramirez
 Author URI: https://github.com/sanruiz
-Version: 3.1.11
+Version: 3.1.12
 */


### PR DESCRIPTION
## Release v3.1.12 - TeamMember Elementor Widget

This PR prepares the release of version 3.1.12.

### Version Changes
- style.css: v3.1.11 → v3.1.12
- CHANGELOG.md: Updated with release date 2026-01-08
- PR Reference: Added link to merged PR #164

### Includes (from merged PR #164)
- TeamMember Elementor widget (485 lines)
- Widget CSS (183 lines)
- Integration tests (253 lines)
- Testing documentation (739 lines)
- isset() null safety fixes for 5 widgets

### Related
- Merged PR: #164
- Base: week-4