### PR TITLE
docs: Update release instructions to prevent manual creation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -366,9 +366,11 @@ gh release view vX.Y.Z | cat
 
 **Expected CI/CD Flow:**
 1. ✅ Stage 1: Quality Gates (code-quality, php-tests, frontend-build) ~2min
-2. ✅ Stage 2: Build & Release (creates soma-vX.Y.Z.zip, GitHub release) ~1min
+2. ✅ Stage 2: Build & Release (creates soma-vX.Y.Z.zip, GitHub release **automatically**) ~1min
 3. ✅ Stage 3: Deploy to Production (SFTP upload, backup, extract) ~2min
 4. ✅ Total: ~5-6 minutes
+
+**⚠️ IMPORTANT**: The GitHub release is created **automatically** by the ci-cd.yml workflow. NEVER use `gh release create` manually.
 
 ---
 

--- a/.github/instructions/github-workflow.instructions.md
+++ b/.github/instructions/github-workflow.instructions.md
@@ -835,13 +835,23 @@ gh release list | cat
 # View release
 gh release view TAG | cat
 
-# Create release (manual - usually done by workflow)
-gh release create v3.0.1 \
-  --title "SOMA Theme v3.0.1" \
-  --notes "See CHANGELOG.md for details" \
-  soma-v3.0.1.zip | cat
+# ⚠️ NEVER create releases manually with gh release create
+# Releases are ALWAYS created automatically by ci-cd.yml workflow
+# when a tag is pushed. The workflow handles:
+# - Building the release package
+# - Generating release notes from CHANGELOG.md
+# - Creating the GitHub release
+# - Uploading artifacts
+# - Deploying to production
+#
+# To create a release:
+# 1. Update version in style.css
+# 2. Update CHANGELOG.md
+# 3. Commit changes
+# 4. Create and push tag: git tag -a v3.0.1 -m "Release v3.0.1" && git push origin v3.0.1
+# 5. Monitor workflow: gh run watch | cat
 
-# Delete release
+# Delete release (emergency only - requires re-tag)
 gh release delete TAG | cat
 ```
 

--- a/wp-content/themes/soma/CHANGELOG.md
+++ b/wp-content/themes/soma/CHANGELOG.md
@@ -22,6 +22,7 @@ This release adds a new TeamMember Elementor widget that replicates the team mem
 ### ✨ Added
 
 #### New Elementor Widget
+
 - **TeamMember Widget** - New Elementor widget for displaying individual team member profiles
   - Replicates complete team-members single page structure and design
   - Auto-detects team member from URL context when used in global templates (Header/Footer)
@@ -47,10 +48,12 @@ This release adds a new TeamMember Elementor widget that replicates the team mem
 ### 📦 Files Changed
 
 #### Added
+
 - `includes/Elementor/Widgets/TeamMember.php` - New TeamMember widget (531 lines)
 - `assets/css/widgets/team-member.css` - Widget-specific styles with flexbox layout
 
 #### Modified
+
 - `wp-content/themes/soma/CHANGELOG.md` - Version documentation
 
 ---
@@ -72,12 +75,14 @@ This patch release fixes the stock price display issue on the company page and r
 ### 🐛 Fixed
 
 #### JavaScript Execution
+
 - **ShareQuotation Component** - Fixed stock price showing $0 on `/company/` page (#158)
   - Added `safeInit()` wrapper for Slick-dependent handlers to prevent uncaught errors from halting JS execution
   - Slick carousel errors now logged as warnings instead of crashing the script
   - Removed debug console.logs from `main.js` and `ShareQuotation.js`
 
 #### Footer Partial
+
 - **HTML Tags Visible on Mobile** - Fixed `<br>` tags showing as literal text instead of rendering (#159)
   - Changed `logo_subtext` from `esc_html()` to `wp_kses_post()` to allow safe HTML
   - Changed `copyright` from `esc_html()` to `wp_kses_post()` for consistency with Elementor widget
@@ -102,33 +107,39 @@ This release enhances the Stock Data admin panel with configurable sync interval
 ### ✨ Added
 
 #### Documents Widget Category Filter
+
 - **Category Dropdown** - New Elementor control to filter documents by taxonomy category (#151)
 - **Dynamic Filtering** - Documents automatically filtered based on selected category
 - **Empty State Handling** - Shows all documents when no category selected
 
 #### Stock Data Admin Panel
+
 - **Configurable Sync Interval** - New dropdown to select stock data update frequency (1, 2, 3, 6, 12, or 24 hours)
 - **Test API Connection Button** - Quick button to test Yahoo Finance API connectivity without waiting for cron
 - **Sync Status Display** - Shows last sync time, current cached data, and next scheduled sync
 - **Real-time Feedback** - AJAX-powered status updates and API test results
 
 #### External JavaScript Module
+
 - **stock-data.js** - New external JavaScript file using IIFE module pattern
 - **wp_localize_script Integration** - Proper WordPress data passing (nonce, i18n strings, AJAX URL)
 
 #### Documentation
+
 - **Elementor Widgets Instructions** - New `.github/instructions/elementor-widgets.instructions.md` with complete widget development workflow
 - **Global Styles Examples** - Documentation for using `Global_Colors` and `Global_Typography` in Elementor widgets
 
 ### 🔄 Changed
 
 #### Code Quality Improvements
+
 - **External JavaScript** - Refactored inline JavaScript (~100 lines) to external `assets/js/admin/stock-data.js`
 - **External CSS** - Refactored inline CSS (~35 lines) to external `assets/css/admin/stock-data.css`
 - **Explicit Cron Intervals** - Changed from dynamic loop to explicit interval definitions for PHPCS compliance
 - **Removed Unnecessary Comments** - Cleaned up phpcs:ignore comment that was no longer needed
 
 #### TeamMembers Widget
+
 - **Variable Naming Clarity** - Renamed `$member_title` to `$member_position` to better reflect ACF field purpose (#153)
 - **Field Mapping Documentation** - Added inline comments documenting image (Featured Image) and position (ACF `team_member_info.title`) field sources
 
@@ -141,6 +152,7 @@ This release enhances the Stock Data admin panel with configurable sync interval
 ### 🌐 Translations
 
 #### Stock Data Admin (22 strings)
+
 - `Test API Connection` → `Probar Conexión API`
 - `Testing...` → `Probando...`
 - `Request failed` → `Solicitud fallida`
@@ -165,6 +177,7 @@ This release enhances the Stock Data admin panel with configurable sync interval
 - `Stock Data` → `Datos Bursátiles`
 
 #### TeamMembers Widget (6 strings)
+
 - `Category` → `Categoría`
 - `Section Title` → `Título de Sección`
 - `Margin Bottom` → `Margen Inferior`
@@ -173,6 +186,7 @@ This release enhances the Stock Data admin panel with configurable sync interval
 - `Position` → `Cargo`
 
 #### Breadcrumb Widget (11 strings)
+
 - `SOMA Breadcrumb` → `Migas de Pan SOMA`
 - `Breadcrumb Settings` → `Configuración de Migas de Pan`
 - `Separator` → `Separador`
@@ -185,6 +199,7 @@ This release enhances the Stock Data admin panel with configurable sync interval
 - `Breadcrumb Navigation` → `Navegación de Migas de Pan`
 
 #### Portfolio Widget (28 strings)
+
 - `Main Category` → `Categoría Principal`
 - `Filter Categories` → `Filtrar Categorías`
 - `Initial Posts` → `Publicaciones Iniciales`
@@ -212,9 +227,11 @@ This release enhances the Stock Data admin panel with configurable sync interval
 - `View Toggle` → `Cambio de Vista`
 
 #### Documents Widget (1 string)
+
 - `Select a category to filter documents...` → `Selecciona una categoría para filtrar documentos...`
 
 #### Helper Functions (4 strings)
+
 - `Search results for: %s` → `Resultados de búsqueda para: %s`
 - `Page Not Found` → `Página No Encontrada`
 - `Blog` → `Blog`
@@ -223,11 +240,13 @@ This release enhances the Stock Data admin panel with configurable sync interval
 ### 📦 Files Changed
 
 #### Added
+
 - `assets/js/admin/stock-data.js` - External JavaScript module for admin panel (150 lines)
 - `assets/css/admin/stock-data.css` - External CSS for admin panel
 - `.github/instructions/elementor-widgets.instructions.md` - Elementor widget development workflow
 
 #### Modified
+
 - `includes/Admin/StockData.php` - Sync interval control, test API button, status display, external JS/CSS enqueue, CSRF protection
 - `includes/Elementor/Widgets/Documents.php` - Added category filter control
 - `includes/Elementor/Widgets/TeamMembers.php` - Variable rename for clarity, field mapping documentation
@@ -256,11 +275,13 @@ This release improves the TeamMembers Elementor widget with modular single-categ
 ### ✨ Added
 
 #### TeamMembers Widget
+
 - **Modular Design** - Widget now accepts a single category per instance for flexible page layouts (#145)
 - **Integration Tests** - 18 tests covering widget structure, CSS variables, and responsive breakpoints
 - **Column Configuration** - Support for 2, 3, or 4 column layouts
 
 #### StockData System
+
 - **ACF Options Integration** - Stock API credentials now stored in ACF options page (#147)
 - **WordPress Options Fallback** - Graceful fallback to WordPress options when ACF not available
 - **Comprehensive Tests** - 26 new tests for StockData admin class and REST endpoint
@@ -268,6 +289,7 @@ This release improves the TeamMembers Elementor widget with modular single-categ
 ### 🔄 Changed
 
 #### CSS Variables Integration
+
 - **Typography** - Name and position use `--soma-font-size-h3`, `--soma-font-size-body`, `--soma-font-family-primary`
 - **Colors** - Text colors use `--soma-color-text-primary`, `--soma-color-text-secondary`
 - **Spacing** - Grid gaps and padding use `--soma-spacing-*` variables
@@ -275,16 +297,19 @@ This release improves the TeamMembers Elementor widget with modular single-categ
 - **Layout** - Container uses `--soma-container-max-width`
 
 #### Responsive Breakpoints
+
 - **Tablet (991px)** - Uses `--soma-font-size-h5`, `--soma-font-size-body-mobile`
 - **Mobile (767px)** - Uses `--soma-font-size-h3-mobile`, `--soma-font-size-small`
 
 #### StockData Refactor
+
 - **Configuration** - API credentials moved from hardcoded values to ACF options
 - **Type Safety** - Added explicit return type hints and casts
 
 ### 📦 Files Changed
 
 #### Added
+
 - `tests/Integration/Elementor/TeamMembersWidgetTest.php` - 18 integration tests
 - `tests/Integration/API/StockDataEndpointTest.php` - REST API tests
 - `tests/Integration/Admin/StockDataTest.php` - Admin integration tests
@@ -293,6 +318,7 @@ This release improves the TeamMembers Elementor widget with modular single-categ
 - `local.env.example` - Environment variables example file
 
 #### Modified
+
 - `includes/Elementor/Widgets/TeamMembers.php` - Modular single-category design with Elementor defaults
 - `assets/css/widgets/team-members.css` - Full SOMA CSS variables integration
 - `includes/Admin/StockData.php` - ACF options integration with WordPress fallback
@@ -303,6 +329,7 @@ This release improves the TeamMembers Elementor widget with modular single-categ
 ### 🌐 Translations
 
 #### TeamMembers Widget (20 strings)
+
 - `All Categories` → `Todas las Categorías`
 - `Number of Members` → `Número de Miembros`
 - `Show Section Title` → `Mostrar Título de Sección`
@@ -325,6 +352,7 @@ This release improves the TeamMembers Elementor widget with modular single-categ
 - `Order` → `Orden`
 
 #### Breadcrumb Widget (11 strings)
+
 - `SOMA Breadcrumb` → `Migas de Pan SOMA`
 - `Breadcrumb Settings` → `Configuración de Migas de Pan`
 - `Separator` → `Separador`
@@ -337,6 +365,7 @@ This release improves the TeamMembers Elementor widget with modular single-categ
 - `Breadcrumb Navigation` → `Navegación de Migas de Pan`
 
 #### Portfolio Widget (28 strings)
+
 - `Main Category` → `Categoría Principal`
 - `Filter Categories` → `Filtrar Categorías`
 - `Initial Posts` → `Publicaciones Iniciales`
@@ -364,6 +393,7 @@ This release improves the TeamMembers Elementor widget with modular single-categ
 - `View Toggle` → `Cambio de Vista`
 
 #### Helper Functions (3 strings)
+
 - `Search results for: %s` → `Resultados de búsqueda para: %s`
 - `Page Not Found` → `Página No Encontrada`
 - `Blog` → `Blog`
@@ -389,6 +419,7 @@ This release completes the Portfolio Elementor widget with dynamic category filt
 ### ✨ Added
 
 #### Portfolio Widget Enhancements
+
 - **Dynamic Category Filters** - Portfolio widget now displays interactive category filter buttons that filter content via AJAX (Issue #17)
 - **Filter Position Control** - New Elementor control to position filters left, center, or right
 - **Filter Spacing Control** - New control to adjust spacing between filter buttons using CSS `gap`
@@ -397,6 +428,7 @@ This release completes the Portfolio Elementor widget with dynamic category filt
 - **Portfolio Widget Tests** - 17 integration tests covering widget controls, rendering, and API integration
 
 #### REST API Improvements
+
 - **Portfolio Categories** - New `include_categories=true` parameter returns available portfolio categories
 - **Category Filtering** - Filter portfolio items by category slug via `category` parameter
 - **Fibrasoma Exclusion** - Fibrasoma category automatically excluded from public category lists
@@ -404,21 +436,25 @@ This release completes the Portfolio Elementor widget with dynamic category filt
 ### 🔄 Changed
 
 #### CSS & Styling
+
 - **Filter Layout** - Changed from `margin-right` to `gap` for filter spacing (better flexbox support)
 - **Font Family** - Updated to "Neue Haas Unica Pro" in CSS variables
 - **Responsive Filters** - Improved mobile responsiveness for filter buttons
 
 #### Code Quality
+
 - **PHPCS Compliance** - Fixed unsanitized `$_GET` input in Portfolio widget with proper `sanitize_text_field()`
 - **Test Cleanup** - Removed deprecated `setAccessible(true)` call in StockPriceWidgetTest
 
 ### 📦 Files Changed
 
 #### Added
+
 - `assets/js/widgets/portfolio.js` - Client-side AJAX filtering logic
 - `tests/Integration/Elementor/PortfolioWidgetTest.php` - 17 integration tests
 
 #### Modified
+
 - `includes/Elementor/Widgets/Portfolio.php` - Dynamic filters, AJAX loading, new controls
 - `includes/API/Endpoints/PortfolioEndpoint.php` - Category filtering support
 - `assets/css/widgets/portfolio.css` - Flexbox layout with gap, improved responsive
@@ -446,6 +482,7 @@ This release adds a new Breadcrumb Elementor widget for content page navigation.
 ### ✨ Added
 
 #### New Elementor Widget
+
 - **Breadcrumb Widget** - Clean navigation breadcrumb widget for content pages (#134)
   - Uses Global_Colors and Global_Typography from Elementor Site Kit
   - Customizable separator (text or icon)
@@ -455,6 +492,7 @@ This release adds a new Breadcrumb Elementor widget for content page navigation.
   - Full typography and color controls for all elements
 
 #### Helper Functions
+
 - **`soma_get_breadcrumb_items()`** - Flexible breadcrumb generation helper function
   - Supports hierarchical pages and custom post types
   - Returns array of breadcrumb items with title and URL
@@ -463,11 +501,13 @@ This release adds a new Breadcrumb Elementor widget for content page navigation.
 ### 📦 Files Changed
 
 #### Added
+
 - `includes/Elementor/Widgets/Breadcrumb.php` - Breadcrumb widget (425 lines)
 - `assets/css/widgets/breadcrumb.css` - Widget styles (49 lines)
 - `tests/Integration/Elementor/BreadcrumbWidgetTest.php` - 15 integration tests
 
 #### Modified
+
 - `includes/Elementor/Loader.php` - Register Breadcrumb widget
 - `includes/Utils/Helpers.php` - Added `soma_get_breadcrumb_items()` function
 - `tests/Integration/Elementor/AllWidgetsTest.php` - Include Breadcrumb widget
@@ -495,6 +535,7 @@ This patch release completes Spanish translations for all theme components and i
 ### ✨ Added
 
 #### Internationalization (i18n)
+
 - **Complete Spanish Translations** - Added 170+ Spanish translations covering all theme components
 - **Elementor Widgets** - All 10 widget titles, descriptions, and controls translated
 - **PostType Enum** - Labels for Portfolio, News, Careers, Team Members, Events, Documents
@@ -506,17 +547,20 @@ This patch release completes Spanish translations for all theme components and i
 ### 🐛 Fixed
 
 #### Code Quality
+
 - **PHPCS Compliance** - Fixed `count()` inside while loop in Documents widget (moved to variable before loop)
 
 ### 🔄 Changed
 
 #### Documents Widget
+
 - **Layout Improvements** - Enhanced grid layout for better document display
 - **Responsive Styles** - Improved mobile responsiveness for document cards
 
 ### 📦 Files Changed
 
 #### Modified
+
 - `languages/es_ES.po` - Added 170+ Spanish translations
 - `languages/es_ES.mo` - Compiled binary translation file
 - `includes/Elementor/Widgets/Documents.php` - PHPCS fix and layout improvements
@@ -541,25 +585,30 @@ This release adds two new Elementor widgets (StockPrice and Documents) and inclu
 ### ✨ Added
 
 #### New Elementor Widgets
+
 - **Documents Widget** - Display documents from `documents-reports` CPT in responsive grid layout with i18n support for bilingual file downloads (#128)
 - **StockPrice Widget** - Display current stock price from cached stock data with configurable styling (#126)
 
 #### Documentation
+
 - **Manual Issue Closure Note** - Added documentation about manual issue closure for non-default branch merges (#125)
 
 ### 🐛 Fixed
 
 #### Cron & Scheduling
+
 - **Stock Data Cron** - Register cron schedule before using it in StockData endpoint (#124)
 
 ### 🔄 Changed
 
 #### Code Quality
+
 - **StockDataEndpoint Refactor** - Use `soma_get_stock_data()` helper instead of direct transient access (#127)
 
 ### 📦 Files Changed
 
 #### Added
+
 - `includes/Elementor/Widgets/Documents.php` - Documents grid widget (485 lines)
 - `includes/Elementor/Widgets/StockPrice.php` - Stock price display widget
 - `assets/css/widgets/documents.css` - Documents widget styles (148 lines)
@@ -568,6 +617,7 @@ This release adds two new Elementor widgets (StockPrice and Documents) and inclu
 - `tests/Integration/Elementor/StockPriceWidgetTest.php` - Integration tests
 
 #### Modified
+
 - `includes/Elementor/Loader.php` - Register new widgets
 - `includes/Core/Theme.php` - Loader registration order fix
 - `includes/API/Endpoints/StockDataEndpoint.php` - Use helper function
@@ -599,6 +649,7 @@ This patch release restores backward compatibility for the team-members post typ
 ### 🐛 Fixed
 
 #### Post Type Slug
+
 - **team-members Post Type** - Restored original hyphenated slug `'team-members'` (was incorrectly changed to `'team_members'` during v3.0.0 refactoring)
 - **Backward Compatibility** - Existing Team Members posts created before v3.0.0 are now accessible again
 - **Database Consistency** - Post type slug now matches existing database records
@@ -606,6 +657,7 @@ This patch release restores backward compatibility for the team-members post typ
 ### 📦 Files Changed
 
 #### Modified
+
 - `wp-content/themes/soma/includes/Core/Enums/PostType.php` - Changed `TEAM_MEMBERS` enum value from `'team_members'` to `'team-members'`
 
 ---
@@ -629,6 +681,7 @@ This patch release fixes Elementor widget style conflicts and adds important sec
 ### 🐛 Fixed
 
 #### Elementor Styles
+
 - **Global Styles Override** - Simplified exclusion selectors to prevent global typography from affecting Elementor widgets
 - **CSS Specificity** - Changed from complex `:not()` with multiple conditions to simple `:not(.elementor a)` pattern
 - **Widget Styling** - Elementor widgets now maintain their specific styles without interference from theme globals
@@ -636,6 +689,7 @@ This patch release fixes Elementor widget style conflicts and adds important sec
 ### ✨ Added
 
 #### Security & CI/CD
+
 - **CodeQL Security Analysis** - Automated code scanning for security vulnerabilities
 - **Git Hooks** - Pre-commit hooks to enforce branch protection and prevent direct commits to protected branches
 - **Branch Protection** - Blocks commits to `main`, `week-*`, and `develop` branches
@@ -644,6 +698,7 @@ This patch release fixes Elementor widget style conflicts and adds important sec
 ### 🔄 Changed
 
 #### Workflow Improvements
+
 - **Release Process** - Enforced GitFlow: only tags from `main` trigger releases and deployments
 - **Branch Strategy** - Documented sprint-based workflow with `week-*` branches
 - **Quality Gates** - CI runs on all PRs to `week-*` and `main` branches
@@ -651,11 +706,13 @@ This patch release fixes Elementor widget style conflicts and adds important sec
 ### 📦 Files Changed
 
 #### Modified
+
 - `wp-content/themes/soma/sass/_general.scss` - Simplified Elementor exclusion selectors
 - `.github/workflows/ci-cd.yml` - Added main branch restriction for releases
 - `.github/workflows/codeql.yml` - New security scanning workflow
 
 #### Added
+
 - `install-hooks.sh` - Git hooks installation script
 - `.git/hooks/pre-commit` - Branch protection enforcement
 
@@ -682,6 +739,7 @@ This patch release fixes asset versioning to use a single source of truth from `
 ### 🐛 Fixed
 
 #### Asset Versioning
+
 - **Outdated Version Numbers** - Assets were loading with version 2.0.7 instead of current version
 - **Browser Caching Issues** - New styles not appearing due to old version numbers in query strings
 - **Hardcoded Versions** - Eliminated hardcoded `$version` and `$legacy_version` properties
@@ -690,6 +748,7 @@ This patch release fixes asset versioning to use a single source of truth from `
 ### 🔄 Changed
 
 #### Single Source of Truth Pattern
+
 - **Assets.php** - Now reads version from `style.css` header using `wp_get_theme()->get('Version')` in constructor
 - **Theme.php** - `get_version()` method uses `wp_get_theme()->get('Version')` instead of hardcoded constant
 - **Removed** - `VERSION` constant from Theme.php
@@ -699,6 +758,7 @@ This patch release fixes asset versioning to use a single source of truth from `
 ### 📦 Files Changed
 
 #### Modified
+
 - `wp-content/themes/soma/includes/Core/Assets.php` - Dynamic version loading
 - `wp-content/themes/soma/includes/Core/Theme.php` - Removed hardcoded constant
 
@@ -722,6 +782,7 @@ This patch release fixes a critical race condition in the CI/CD pipeline that ca
 ### 🐛 Fixed
 
 #### CI/CD Architecture
+
 - **Race Condition Eliminated** - Unified `ci-cd.yml` replaces separate `quality-and-tests.yml` and `release-and-deploy.yml` workflows
 - **Sequential Execution** - Stage 2 (Build & Release) waits for Stage 1 (Quality Gates) completion via `needs:` keyword
 - **Deployment Reliability** - Stage 3 (Deploy) executes only after successful release creation
@@ -733,6 +794,7 @@ This patch release fixes a critical race condition in the CI/CD pipeline that ca
 ### ✨ Added
 
 #### Workflow Architecture
+
 - **Unified CI/CD Pipeline** - Single `.github/workflows/ci-cd.yml` (546 lines) with 3-stage architecture
 - **Stage 1: Quality Gates** (parallel execution, always runs)
   - `code-quality`: PHPCS strict + PHPStan Level 6+ (~27s)
@@ -750,6 +812,7 @@ This patch release fixes a critical race condition in the CI/CD pipeline that ca
 - **Stage 4: Pipeline Summary** (always runs, reports all stage results)
 
 #### Documentation
+
 - **Comprehensive CI/CD Guide** - New `docs/workflows/CI_CD.md` (600+ lines)
   - Architecture overview with visual flow diagram
   - Detailed job descriptions for all stages
@@ -764,11 +827,13 @@ This patch release fixes a critical race condition in the CI/CD pipeline that ca
 ### 🔄 Changed
 
 #### Workflow Files
+
 - **Replaced**: `.github/workflows/quality-and-tests.yml` (302 lines, deleted)
 - **Replaced**: `.github/workflows/release-and-deploy.yml` (357 lines, deleted)
 - **Created**: `.github/workflows/ci-cd.yml` (546 lines, unified pipeline)
 
 #### Execution Flow
+
 - **OLD**: Separate workflows triggered simultaneously on tag push → race condition → wait-for-ci job → deployment failures
 - **NEW**: Single workflow with guaranteed sequential stages → no race conditions → reliable deployment
 
@@ -777,15 +842,18 @@ This patch release fixes a critical race condition in the CI/CD pipeline that ca
 ### 📦 Files Changed
 
 #### Created
+
 - `.github/workflows/ci-cd.yml` - Unified CI/CD pipeline (546 lines)
 - `docs/workflows/CI_CD.md` - Comprehensive workflow documentation (600+ lines)
 
 #### Modified
+
 - `docs/WORKFLOWS.md` - Updated with unified architecture, new quick start, troubleshooting
 - `docs/workflows/QUALITY_AND_TESTS.md` - Added deprecation notice and migration guide
 - `docs/workflows/RELEASE_AND_DEPLOY.md` - Added deprecation notice and migration guide
 
 #### Deleted
+
 - `.github/workflows/quality-and-tests.yml` - Merged into ci-cd.yml
 - `.github/workflows/release-and-deploy.yml` - Merged into ci-cd.yml
 
@@ -834,17 +902,20 @@ This release adds full Elementor support to base WordPress templates, enabling v
 ### ✨ Added
 
 #### Elementor Integration
+
 - **Full Template Support** - `single.php`, `page.php`, and `index.php` now support Elementor editor
 - **Dedicated Elementor Template** - New `elementor-template.php` for pages built entirely with Elementor
 - **Conditional Rendering** - Automatically detects Elementor content vs ACF blocks
 - **Backward Compatible** - Existing ACF flexible content continues to work seamlessly
 
 #### CI/CD & Automation
+
 - **Quality Checks for PRs** - `quality-and-tests.yml` now runs on PRs to `week-*` branches
 - **GitHub Workflow Documentation** - Comprehensive guide in `.github/instructions/github-workflow.instructions.md`
 - **Custom Instructions System** - YAML frontmatter support for path-specific coding standards
 
 #### Developer Experience
+
 - **i18n Helper Enhancement** - `soma_get_i18n_field()` for unified language-specific field handling
 - **API Language Support** - REST endpoints use helper for consistent multilingual field access
 - **WordPress Coding Standards** - Fixed 644 PHPCS errors, improved code quality
@@ -854,11 +925,13 @@ This release adds full Elementor support to base WordPress templates, enabling v
 ### 🔄 Changed
 
 #### Template Architecture
+
 - **Base Templates Enhanced** - All main templates check for Elementor before rendering ACF blocks
 - **Content Function** - Reverted `the_content()` to dedicated Elementor template instead of modifying core templates
 - **Template Hierarchy** - Added Elementor template to WordPress template hierarchy
 
 #### Code Quality
+
 - **PHPUnit Configuration** - Fixed textdomain redeclaration warnings in test suite
 - **API Endpoints** - Migrated language conditionals to use `soma_get_i18n_field()` helper
 - **Workflow Improvements** - Enhanced CI/CD reliability and test coverage
@@ -868,10 +941,12 @@ This release adds full Elementor support to base WordPress templates, enabling v
 ### 🐛 Fixed
 
 #### Testing
+
 - **PHPUnit Warnings** - Resolved textdomain redeclaration issues in test bootstrap
 - **WordPress Test Suite** - Properly configured for Local by Flywheel environment
 
 #### Code Standards
+
 - **PHPCS Compliance** - Fixed 644 coding standard violations
 - **Type Safety** - Improved type hints and documentation across codebase
 
@@ -880,11 +955,13 @@ This release adds full Elementor support to base WordPress templates, enabling v
 ### 📦 Files Changed
 
 #### Added
+
 - `.github/instructions/github-workflow.instructions.md` - GitHub workflow standards
 - `.github/instructions/documentation-language.instructions.md` - Updated with YAML frontmatter
 - `elementor-template.php` - Dedicated Elementor page template
 
 #### Modified
+
 - `single.php` - Added Elementor support check
 - `page.php` - Added Elementor support check
 - `index.php` - Added Elementor support check
@@ -905,6 +982,7 @@ This release adds full Elementor support to base WordPress templates, enabling v
 ### 🚀 Deployment
 
 This version enables:
+
 - Visual page building with Elementor widgets (8 custom widgets available)
 - Mixed content approach (ACF blocks + Elementor sections on same site)
 - Improved developer workflow with automated quality checks
@@ -927,6 +1005,7 @@ SOMA v3.0.0 is a **complete rewrite** bringing modern PHP standards, enterprise-
 ### ✨ Added
 
 #### Internationalization (i18n) System
+
 - **WordPress i18n Standard** - Full compliance with WordPress internationalization best practices
 - **Translation Helper Function** - `soma_get_i18n_field()` for ACF field internationalization with language variants
 - **Translation Files** - Complete Spanish (es_ES) translation with .pot template, .po source, and .mo compiled files
@@ -935,6 +1014,7 @@ SOMA v3.0.0 is a **complete rewrite** bringing modern PHP standards, enterprise-
 - **i18n Documentation** - Complete internationalization guide in `docs/INTERNATIONALIZATION.md`
 
 #### Architecture & Infrastructure
+
 - **PSR-4 Autoloading** - Complete namespace structure with `Soma\` base namespace
 - **Composer Integration** - Modern dependency management with autoloader
 - **LoadableInterface System** - Standardized component loading with priorities (10-50)
@@ -942,6 +1022,7 @@ SOMA v3.0.0 is a **complete rewrite** bringing modern PHP standards, enterprise-
 - **PHP 8.1+ Features** - Enums, match expressions, first-class callables, readonly properties
 
 #### Core Components
+
 - **3 Custom Taxonomies** - Portfolio, News, Team Members taxonomies with enum configuration
 - **Taxonomy Enum** (`Soma\Core\Enums\Taxonomy`) - Type-safe taxonomy references with 5 helper methods
 - **PostType Enum** (`Soma\Core\Enums\PostType`) - Type-safe post type identifiers
@@ -949,6 +1030,7 @@ SOMA v3.0.0 is a **complete rewrite** bringing modern PHP standards, enterprise-
 - **CacheTag Enum** (`Soma\Utils\Enums\CacheTag`) - Type-safe cache tag identifiers
 
 #### Helper Functions System (25 functions)
+
 - **Logger Helpers (9)** - `soma_log_emergency()`, `soma_log_alert()`, `soma_log_critical()`, `soma_log_error()`, `soma_log_warning()`, `soma_log_notice()`, `soma_log_info()`, `soma_log_debug()`, `soma_get_logger()`
 - **Cache Helpers (6)** - `soma_cache_get()`, `soma_cache_set()`, `soma_cache_remember()`, `soma_cache_invalidate_tags()`, `soma_cache_flush()`, `soma_get_cache()`
 - **Post Type Helpers (4)** - `soma_get_portfolio_items()`, `soma_get_news_items()`, `soma_get_careers_items()`, `soma_get_team_members()`
@@ -959,6 +1041,7 @@ SOMA v3.0.0 is a **complete rewrite** bringing modern PHP standards, enterprise-
 - **Stock Data (1)** - `soma_get_stock_data()`
 
 #### Caching System
+
 - **PSR-16 Cache Implementation** - Simple cache interface with WordPress object cache backend
 - **Tag-Based Invalidation** - Group cache entries by tags for bulk invalidation
 - **Automatic Cache Invalidation** - Auto-invalidates on `save_post` and ACF save hooks
@@ -967,6 +1050,7 @@ SOMA v3.0.0 is a **complete rewrite** bringing modern PHP standards, enterprise-
 - **CacheInvalidationManager** - Centralized invalidation with tag tracking
 
 #### Logging System
+
 - **PSR-3 Logger** - Full PSR-3 compliance with 8 severity levels
 - **File-Based Logging** - Logs to `wp-content/uploads/soma-logs/soma.log`
 - **Contextual Logging** - Rich context support for debugging
@@ -974,6 +1058,7 @@ SOMA v3.0.0 is a **complete rewrite** bringing modern PHP standards, enterprise-
 - **Helper Functions** - Simple `soma_log_*()` functions for all log levels
 
 #### Elementor Integration
+
 - **8 Custom Widgets** - Navbar, Footer, Business Units, Services, Team Members, News List, Portfolio, Contact Form
 - **Custom Widget Category** - 'soma' category in Elementor panel
 - **ACF Data Integration** - Widgets can access ACF fields seamlessly
@@ -983,6 +1068,7 @@ SOMA v3.0.0 is a **complete rewrite** bringing modern PHP standards, enterprise-
 - **Icon Controls** - Icon library integration for visual elements
 
 #### PageBuilder Enhancements
+
 - **BlockRegistry** - Centralized mapping of 53 blocks (layout → field_group → partial)
 - **BlockRenderer** - Advanced rendering engine with validation, error handling, and optional caching
 - **Multi-Layer Validation** - Structure validation, registry validation, file existence checks
@@ -992,6 +1078,7 @@ SOMA v3.0.0 is a **complete rewrite** bringing modern PHP standards, enterprise-
 - **LoadableInterface** - Priority-based loading (priority 25)
 
 #### Testing Infrastructure
+
 - **PHPUnit Integration** - Comprehensive unit and integration tests
 - **108 Tests** - 355 assertions across 24 test files
 - **Test Organization** - Separate unit and integration test suites
@@ -1001,6 +1088,7 @@ SOMA v3.0.0 is a **complete rewrite** bringing modern PHP standards, enterprise-
 - **SOMA_TESTING Constant** - Clean test output without error_log noise
 
 #### Code Quality Tools
+
 - **PHPCS Integration** - WordPress Coding Standards compliance
 - **PHPStan Static Analysis** - Level 6-8 static type checking
 - **PHPCBF Auto-Fixing** - Automatic code formatting
@@ -1009,6 +1097,7 @@ SOMA v3.0.0 is a **complete rewrite** bringing modern PHP standards, enterprise-
 - **Baseline Support** - `phpstan-baseline.neon` for acceptable warnings
 
 #### Documentation (5,000+ lines)
+
 - **DEVELOPMENT.md** (1,093 lines) - Complete developer guide with 30+ code examples
 - **WIDGETS.md** (900 lines) - Elementor widgets reference with control tables
 - **HELPERS.md** (850+ lines) - API reference for 24 helper functions
@@ -1026,6 +1115,7 @@ SOMA v3.0.0 is a **complete rewrite** bringing modern PHP standards, enterprise-
 #### Breaking Changes
 
 ##### PageBuilder Global Variables → Query Vars (CRITICAL)
+
 ```php
 // ❌ v2.0.7 (OLD - NO LONGER WORKS)
 global $pageBlock;
@@ -1041,6 +1131,7 @@ $title = $block_content['title'] ?? '';
 **Migration**: See [MIGRATION_FROM_V2.md § Code Updates](docs/MIGRATION_FROM_V2.md#code-updates-required)
 
 ##### Directory Structure Reorganization
+
 ```
 ❌ OLD (v2.0.7):          ✅ NEW (v3.0.0):
 inc/                      includes/
@@ -1059,6 +1150,7 @@ inc/                      includes/
 **Migration**: Use namespaced classes instead of `require_once`
 
 ##### Class Structure - Functions → Singletons
+
 ```php
 // ❌ OLD (v2.0.7)
 register_portfolio_post_type();
@@ -1075,12 +1167,14 @@ $items = soma_get_portfolio_items();
 **Migration**: Use singleton classes or helper functions
 
 ##### PHP Version Requirement
+
 - **OLD**: PHP 7.4+ supported
 - **NEW**: PHP 8.1+ required
 
 **Reason**: Enums, first-class callables, match expressions, readonly properties
 
 ##### Hook Registration - Array Syntax → First-Class Callables
+
 ```php
 // ❌ OLD (v2.0.7)
 add_action('init', array($this, 'init'));
@@ -1094,6 +1188,7 @@ add_action('init', $this->init(...));
 #### Non-Breaking Changes
 
 ##### Post Types Migration
+
 - All 4 post types migrated to PSR-4 structure (`Soma\PostTypes\Types\*`)
 - Singleton pattern with `instance()` method
 - LoadableInterface implementation (priority 20)
@@ -1101,6 +1196,7 @@ add_action('init', $this->init(...));
 - Enhanced with helper functions
 
 ##### Custom Fields Migration
+
 - ACF field groups preserved 100% (no changes to field structure)
 - Field registration migrated to PSR-4 classes (`Soma\CustomFields\Fields\*`)
 - Singleton pattern implementation
@@ -1108,6 +1204,7 @@ add_action('init', $this->init(...));
 - JSON sync functionality maintained
 
 ##### REST API Migration
+
 - All 5 endpoints migrated to PSR-4 structure (`Soma\API\Endpoints\*`)
 - Singleton pattern with clean initialization
 - First-class callables for route registration
@@ -1115,17 +1212,20 @@ add_action('init', $this->init(...));
 - Same endpoint URLs maintained (no breaking changes)
 
 ##### CF7 Integration Migration
+
 - Validation classes migrated to PSR-4 (`Soma\CF7\Validations`)
 - Singleton pattern implementation
 - Enhanced error messages
 - Maintained backward compatibility with existing forms
 
 ##### Logger Enhancement
+
 - Test mode suppression (checks `SOMA_TESTING` constant)
 - Performance optimization (single instance, minimal overhead)
 - Log rotation support (future-ready)
 
 ##### Cache System Enhancement
+
 - Performance optimizations
 - Better error handling
 - Tag validation
@@ -1136,17 +1236,20 @@ add_action('init', $this->init(...));
 ### 🐛 Fixed
 
 #### Code Quality Fixes
+
 - **PHPCS Errors**: Reduced from 624 to 154 errors (470 auto-fixed with PHPCBF)
 - **PHPStan Issues**: Achieved Level 6 compliance with 0 critical errors
 - **Baseline Created**: `phpstan-baseline.neon` for 3 acceptable warnings
 - **41 Files Formatted**: Consistent coding standards across codebase
 
 #### Test Error Fixes
+
 - **Logger Error Messages**: Suppressed `error_log()` during tests (added `SOMA_TESTING` check)
 - **Test Output Cleanup**: Clean PHPUnit runs with 0 console errors
 - **108/108 Tests Passing**: All tests green (355 assertions)
 
 #### Documentation Fixes
+
 - **Enum Documentation**: Updated Phase 2.5 docs with enum improvements
 - **Test Coverage**: Corrected test counts (36 → 39 tests)
 - **File Counts**: Updated to reflect actual implementation (8 → 9 files)
@@ -1156,13 +1259,16 @@ add_action('init', $this->init(...));
 ### 🗑️ Deprecated
 
 #### Functions (Backward Compatible)
+
 - `translateDate()` - Use `soma_translate_date()` instead (alias maintained for compatibility)
 
 #### Global Variables (Breaking)
+
 - `$pageBlock` - Use `get_query_var('soma_block_content')` instead
 - `$pageBuilder` - Use `get_query_var('soma_blocks')` instead
 
 #### File Includes (Breaking)
+
 - `require_once get_template_directory() . '/inc/post-types.php'` - Use Composer autoload
 - `require_once get_template_directory() . '/inc/endpoints.php'` - Use Composer autoload
 - `require_once get_template_directory() . '/inc/cf7-validations.php'` - Use Composer autoload
@@ -1172,18 +1278,21 @@ add_action('init', $this->init(...));
 ### 🔒 Security
 
 #### Input Validation
+
 - All user input sanitized through WordPress functions
 - ACF handles field sanitization automatically
 - REST API parameter validation with type checking
 - Nonce verification for all form submissions
 
 #### Output Escaping
+
 - All dynamic output escaped with context-aware functions
 - XSS prevention in templates and partials
 - SQL injection prevention (prepared statements only)
 - File upload validation
 
 #### Authentication & Authorization
+
 - Proper capability checks for admin functions
 - REST API permission callbacks implemented
 - Admin area restrictions enforced
@@ -1194,12 +1303,14 @@ add_action('init', $this->init(...));
 ### 📊 Performance
 
 #### Improvements
+
 - **Caching System**: Tag-based caching reduces database queries
 - **Autoloading**: Composer autoload faster than manual includes
 - **Helper Functions**: Optimized query patterns with `soma_get_*_items()`
 - **Asset Optimization**: Minified CSS/JS with versioning
 
 #### Benchmarks (Estimated)
+
 - **Page Load Time**: < 2.5s average (homepage)
 - **Database Queries**: < 40 average per page
 - **Cache Hit Rate**: > 90% for repeated requests
@@ -1210,6 +1321,7 @@ add_action('init', $this->init(...));
 ### 🧪 Testing
 
 #### Test Coverage
+
 - **Total Tests**: 108 tests, 355 assertions
 - **Unit Tests**: 75 tests
   - PostTypes: 24 tests (Portfolio, News, Careers, TeamMembers)
@@ -1223,6 +1335,7 @@ add_action('init', $this->init(...));
   - PageBuilder Integration: 12 tests
 
 #### Quality Metrics
+
 - **PHPCS**: WordPress Coding Standards compliant (0 errors)
 - **PHPStan**: Level 6 compliance (0 critical errors)
 - **Code Coverage**: Unit test coverage for all critical components
@@ -1233,6 +1346,7 @@ add_action('init', $this->init(...));
 ### 📦 Dependencies
 
 #### Added
+
 - `composer/installers` ^2.0 - WordPress plugin/theme installer
 - `phpunit/phpunit` ^9.0 (dev) - Testing framework
 - `squizlabs/php_codesniffer` ^3.7 (dev) - Coding standards
@@ -1241,6 +1355,7 @@ add_action('init', $this->init(...));
 - `szepeviktor/phpstan-wordpress` ^1.3 (dev) - WordPress PHPStan rules
 
 #### Updated
+
 - Node.js packages updated for security
 - Webpack configuration modernized
 
@@ -1249,6 +1364,7 @@ add_action('init', $this->init(...));
 ### 🏗️ Development
 
 #### New Scripts
+
 ```bash
 composer test         # Run all PHPUnit tests
 composer phpcs        # Check coding standards
@@ -1258,6 +1374,7 @@ composer validate     # Run all quality checks
 ```
 
 #### New Tools
+
 - `scripts/validate-theme.sh` - Complete validation pipeline
 - `tests/bin/install-wp-tests.sh` - WordPress test environment setup
 - Git pre-commit hooks for quality validation
@@ -1267,12 +1384,14 @@ composer validate     # Run all quality checks
 ### 📁 File Changes Summary
 
 #### Phase 1: Foundation & Infrastructure
+
 - **Added**: `composer.json`, `phpstan.neon`, `phpcs.xml`, `phpunit.xml`
 - **Added**: `includes/Core/Loader.php`, `includes/Core/Theme.php`
 - **Added**: `includes/Core/Interfaces/LoadableInterface.php`
 - **Added**: `tests/` directory structure (bootstrap, Unit, Integration, Mocks)
 
 #### Phase 2.1-2.4: Module Migration
+
 - **Added**: 4 files in `includes/PostTypes/Types/` (Portfolio, News, Careers, TeamMembers)
 - **Added**: 1 file `includes/PostTypes/Loader.php`
 - **Added**: 4 files in `includes/CustomFields/Fields/`
@@ -1284,6 +1403,7 @@ composer validate     # Run all quality checks
 - **Removed**: `inc/post-types.php`, `inc/endpoints.php`, `inc/cf7-validations.php` (migrated)
 
 #### Phase 2.5: Taxonomies Migration
+
 - **Added**: `includes/Core/Enums/Taxonomy.php` (119 lines)
 - **Added**: 3 files in `includes/Taxonomies/` (PortfolioTaxonomy, NewsTaxonomy, TeamMembersTaxonomy)
 - **Added**: `includes/Taxonomies/Loader.php`
@@ -1293,6 +1413,7 @@ composer validate     # Run all quality checks
 - **Removed**: `inc/taxonomies.php.deprecated`
 
 #### Phase 3: Utilities & Helpers
+
 - **Added**: `includes/Utils/Helpers.php` (458 lines, 24 functions)
 - **Added**: `includes/Utils/Logger.php` (PSR-3 implementation)
 - **Added**: `includes/Utils/Cache.php` (tag-based caching)
@@ -1302,12 +1423,14 @@ composer validate     # Run all quality checks
 - **Added**: `includes/Core/Enums/PostType.php`
 
 #### Phase 4: Elementor Integration
+
 - **Added**: 8 files in `includes/Elementor/Widgets/` (Navbar, Footer, BusinessUnits, Services, TeamMembers, NewsList, Portfolio, ContactForm)
 - **Added**: `includes/Elementor/Loader.php`
 - **Added**: 8 CSS files in `assets/css/widgets/`
 - **Added**: Integration tests for all widgets
 
 #### Phase 6: PageBuilder Enhancement
+
 - **Added**: `includes/PageBuilder/Loader.php` (235 lines)
 - **Added**: `includes/PageBuilder/BlockRegistry.php` (236 lines, 53 blocks)
 - **Added**: `includes/PageBuilder/BlockRenderer.php` (334 lines)
@@ -1316,6 +1439,7 @@ composer validate     # Run all quality checks
 - **Added**: `docs/TESTING_GUIDE.md` (337 lines)
 
 #### Phase 8: Documentation & Release
+
 - **Added**: `docs/DEVELOPMENT.md` (1,093 lines)
 - **Added**: `docs/WIDGETS.md` (900 lines)
 - **Added**: `docs/HELPERS.md` (850+ lines)
@@ -1324,6 +1448,7 @@ composer validate     # Run all quality checks
 - **Added**: `CHANGELOG.md` (this file)
 
 #### Total Changes
+
 - **Files Added**: 70+ files
 - **Files Modified**: 15+ files
 - **Files Removed**: 5+ deprecated files
@@ -1377,6 +1502,7 @@ composer validate     # Run all quality checks
 Last stable release before v3.0.0 modernization. This version used the traditional WordPress theme structure without PSR-4, Composer, or modern PHP features.
 
 #### Features
+
 - ACF Flexible Content page builder (50+ partials)
 - 4 Custom Post Types (Portfolio, News, Careers, Team Members)
 - 5 REST API endpoints
@@ -1386,6 +1512,7 @@ Last stable release before v3.0.0 modernization. This version used the tradition
 - Basic SCSS architecture
 
 #### Known Issues (Fixed in v3.0)
+
 - No PSR-4 compliance
 - No automated testing
 - No code quality tools

--- a/wp-content/themes/soma/docs/WIDGETS.md
+++ b/wp-content/themes/soma/docs/WIDGETS.md
@@ -240,6 +240,7 @@ $args = [
 #### ACF Integration
 
 **Required ACF Fields on Business Unit Pages:**
+
 - `unit_icon` (Image) - Business unit icon
 - `unit_description` (Textarea) - Short description
 - `unit_link` (Link) - External or internal link
@@ -390,6 +391,7 @@ if (!empty($settings['taxonomy_filter'])) {
 #### ACF Integration
 
 **Required ACF Fields on team-members post type:**
+
 - `member_position` (Text) - Job title
 - `member_bio` (Textarea) - Biography
 - `member_email` (Email) - Contact email
@@ -436,6 +438,7 @@ Displays a single team member profile with photo, name, position, featured text,
 #### Layout
 
 **Responsive 2-Column Flexbox:**
+
 - Left column (50%): Name, Position, Featured Text
 - Right column (50%): Featured Image, Biography  
 - Desktop padding: `60px 0 140px`
@@ -469,6 +472,7 @@ $settings['team_member_id'] = 123; // Specific team member post ID
 #### ACF Integration
 
 **Required ACF Fields on team-members post type:**
+
 - Featured Image (WordPress native)
 - `team_member_info` (Group)
   - `title` (Text) - Job title/position
@@ -636,6 +640,7 @@ if (!empty($settings['taxonomy_filter'])) {
 #### ACF Integration
 
 **Required ACF Fields on portfolio post type:**
+
 - `project_client` (Text) - Client name
 - `project_location` (Text) - Project location
 - `project_year` (Number) - Completion year
@@ -740,11 +745,13 @@ None - Uses CF7 shortcode and widget settings.
 ### Standard Control Groups
 
 **Content Tab:**
+
 - Section settings (title, subtitle)
 - Query settings (number, order, filter)
 - Display options (layout, columns, show/hide)
 
 **Style Tab:**
+
 - Section styling (title, description)
 - Card/item styling (background, borders, spacing)
 - Typography (all text elements)
@@ -752,6 +759,7 @@ None - Uses CF7 shortcode and widget settings.
 - Spacing (padding, margins, gaps)
 
 **Advanced Tab:**
+
 - CSS ID
 - CSS Classes
 - Custom CSS
@@ -1004,12 +1012,14 @@ Use this checklist when creating a new Elementor widget:
 ### Widget Not Appearing in Panel
 
 **Possible Causes:**
+
 1. Widget class not registered in Loader
 2. Elementor cache needs clearing
 3. Widget class has syntax error
 4. Base class not extended
 
 **Solutions:**
+
 ```php
 // 1. Check Loader.php registration
 private function register_widgets(): void {
@@ -1031,12 +1041,14 @@ class YourWidget extends WidgetBase { }
 ### Styles Not Loading
 
 **Possible Causes:**
+
 1. CSS file not enqueued
 2. Style dependencies not declared
 3. File path incorrect
 4. Caching issue
 
 **Solutions:**
+
 ```php
 // 1. Check get_style_depends()
 public function get_style_depends(): array {
@@ -1054,12 +1066,14 @@ soma_cache_flush();
 ### ACF Fields Not Displaying
 
 **Possible Causes:**
+
 1. Field group not assigned to post type
 2. Field key incorrect
 3. ACF not active
 4. Field data not saved
 
 **Solutions:**
+
 ```php
 // 1. Check field exists
 $value = get_field('field_name');
@@ -1079,12 +1093,14 @@ if (!function_exists('get_field')) {
 ### Query Returns No Results
 
 **Possible Causes:**
+
 1. Post type not registered
 2. Incorrect query arguments
 3. No posts published
 4. Taxonomy filter too restrictive
 
 **Solutions:**
+
 ```php
 // 1. Verify post type exists
 if (!post_type_exists('your-post-type')) {
@@ -1122,8 +1138,8 @@ $args['post_status'] = 'publish';
 
 ### Support
 
-- **GitHub Issues**: https://github.com/sanruiz/fibra/issues
-- **Project Board**: https://github.com/users/sanruiz/projects/4
+- **GitHub Issues**: <https://github.com/sanruiz/fibra/issues>
+- **Project Board**: <https://github.com/users/sanruiz/projects/4>
 
 ---
 


### PR DESCRIPTION
Updates Copilot instructions to clarify that GitHub releases should NEVER be created manually with `gh release create`.

**Changes:**
- ⚠️ Added warning in github-workflow.instructions.md that `gh release create` should never be used manually
- 📝 Documented that releases are ALWAYS created automatically by ci-cd.yml workflow
- ✅ Updated release workflow checklist in copilot-instructions.md
- 📋 Clarified proper release process: update version → update CHANGELOG → create tag → push tag → monitor workflow
- 🤖 Added note about automatic GitHub release creation in CI/CD flow description

**Rationale:**
The ci-cd.yml workflow automatically handles:
- Building the release package
- Generating release notes from CHANGELOG.md
- Creating the GitHub release
- Uploading artifacts
- Deploying to production

Manual release creation with `gh release create` bypasses this automated process and can lead to inconsistencies.

**Related:**
- Workflow: .github/workflows/ci-cd.yml
- Instructions: .github/instructions/github-workflow.instructions.md
- Context: .github/copilot-instructions.md