### PR TITLE
fix(elementor): Remove unnecessary card link from TeamMember widget

### DIFF
--- a/wp-content/themes/soma/assets/css/widgets/team-member.css
+++ b/wp-content/themes/soma/assets/css/widgets/team-member.css
@@ -18,23 +18,6 @@
 	padding: 0 var(--soma-spacing-md);
 }
 
-/* Full Card Link */
-.soma-team-member__card-link {
-	display: block;
-	text-decoration: none;
-	color: inherit;
-	transition: var(--soma-transition, 0.3s ease);
-}
-
-.soma-team-member__card-link:hover {
-	opacity: 0.9;
-}
-
-.soma-team-member__card-link:hover .member-name {
-	color: var(--soma-color-primary, #171717);
-	text-decoration: underline;
-}
-
 /* Flexbox 2-column layout */
 .soma-team-member .content {
 	display: flex;

--- a/wp-content/themes/soma/includes/Elementor/Widgets/TeamMember.php
+++ b/wp-content/themes/soma/includes/Elementor/Widgets/TeamMember.php
@@ -460,20 +460,13 @@ class TeamMember extends WidgetBase {
 
 		$info               = get_field( 'team_member_info', $team_member_id );
 		$image              = get_the_post_thumbnail_url( $team_member_id, 'full' );
-		$member_url         = get_permalink( $team_member_id );
 		$show_photo         = 'yes' === ( $settings['show_photo'] ?? 'yes' );
 		$show_logo          = 'yes' === ( $settings['show_logo'] ?? 'yes' );
 		$show_featured_text = 'yes' === ( $settings['show_featured_text'] ?? 'yes' );
-
-		// Determine if we should wrap the entire card in a link.
-		$use_card_link = ! empty( $member_url ) && ( $use_current_member || ! empty( $settings['team_member_id'] ) );
 		?>
 
 		<section class="soma-team-member">
 			<div class="container">
-				<?php if ( $use_card_link ) : ?>
-					<a href="<?php echo esc_url( $member_url ); ?>" class="soma-team-member__card-link">
-				<?php endif; ?>
 				<div class="content">
 					<div class="title">
 						<h3 class="member-name"><?php echo esc_html( get_the_title( $team_member_id ) ); ?></h3>
@@ -500,9 +493,6 @@ class TeamMember extends WidgetBase {
 						</div>
 					<?php endif; ?>
 				</div>
-				<?php if ( $use_card_link ) : ?>
-					</a>
-				<?php endif; ?>
 			</div>
 		</section>
 		<?php


### PR DESCRIPTION
## Description

Remove unnecessary card link functionality from TeamMember widget since it displays complete team member information directly (not a card that links to another page).

## Changes

- Remove `$member_url` variable from TeamMember.php
- Remove `$use_card_link` logic from TeamMember.php  
- Remove `<a>` link wrapper from render output
- Remove `.soma-team-member__card-link` CSS styles and hover effects

## Rationale

The TeamMember widget is designed to display **full team member profile information** (name, title, photo, featured text, biography, SOMA logo) directly on the page. It should not act as a clickable card linking elsewhere.

## Testing

- [x] PHPCS: Clean (0 errors)
- [x] PHPStan: No errors

## Related

Related to #178