### PR TITLE
Release v3.1.18

### DIFF
--- a/wp-content/themes/soma/CHANGELOG.md
+++ b/wp-content/themes/soma/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [3.1.18] - 2026-01-14
+
+### StockPrice Widget Currency Toggle
+
+This patch release adds a toggle control to the StockPrice widget allowing users to show or hide the currency code.
+
+---
+
 ### 🔄 Changed
 
 #### StockPrice Widget
@@ -22,6 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Show Currency Code` → `Mostrar Código de Moneda`
 - `Display currency code (e.g., MXN) after the price.` → `Mostrar código de moneda (ej. MXN) después del precio.`
+
+---
+
+### 🔗 Related Issues & PRs
+
+- **Issue #192**: [Remove the currency](https://github.com/sanruiz/fibra/issues/192) - Closed
+- **PR #200**: [feat(elementor): Add currency toggle to StockPrice widget](https://github.com/sanruiz/fibra/pull/200) - Merged
 
 ---
 

--- a/wp-content/themes/soma/style.css
+++ b/wp-content/themes/soma/style.css
@@ -4,5 +4,5 @@ Theme URI: https://github.com/sanruiz/fibra
 Description: Modern WordPress theme with PSR-4 architecture, ACF flexible content, and Elementor integration.
 Author: Santiago Ramirez
 Author URI: https://github.com/sanruiz
-Version: 3.1.17
+Version: 3.1.18
 */


### PR DESCRIPTION
## Release v3.1.18

Prepares release v3.1.18 with version bump and changelog updates.

### Changes
- Version bump: 3.1.17 → 3.1.18
- CHANGELOG.md updated with release notes

### Features in this release
- StockPrice Widget: Currency code toggle (#192)

See [CHANGELOG.md](wp-content/themes/soma/CHANGELOG.md) for details.