### PR TITLE
docs: Add missing v3.1.21 release notes to CHANGELOG

### DIFF
--- a/wp-content/themes/soma/CHANGELOG.md
+++ b/wp-content/themes/soma/CHANGELOG.md
@@ -42,6 +42,57 @@ This patch release fixes the Slick carousel initialization error and improves th
 
 ---
 
+## [3.1.21] - 2026-01-17
+
+### Team Members Menu Order Support
+
+This patch release adds page-attributes support to the Team Members custom post type, enabling manual ordering via WordPress admin.
+
+---
+
+### ✨ Added
+
+#### Team Members CPT Enhancement
+
+- **Menu Order Support** - Added `page-attributes` to Team Members CPT supports array (#212)
+  - Enables `menu_order` field in WordPress admin for Team Members
+  - Allows manual ordering of team members via "Order" field in admin
+  - Enables Elementor "Order By: Menu Order" functionality for TeamMembers widget
+  - Provides consistent ordering control across widgets and queries
+
+#### Unit Tests
+
+- **TeamMembersTest.php** - New unit test file for Team Members post type
+  - Tests singleton instance pattern
+  - Tests post type registration
+  - Tests supports array includes `page-attributes`
+  - Follows existing PostTypes test patterns
+
+### 🐛 Fixed
+
+#### Test Assertions
+
+- **TeamMembersTest** - Corrected expected value assertions (#212)
+
+### 📦 Files Changed
+
+#### Modified
+
+- `includes/PostTypes/Types/TeamMembers.php` - Added `page-attributes` to supports array
+- `singles/portfolio.php` - Minor spacing fixes (phpcbf auto-fix)
+
+#### Added
+
+- `tests/Unit/PostTypes/TeamMembersTest.php` - New unit test file (47 lines)
+
+---
+
+### 🔗 Related Issues & PRs
+
+- **PR #212**: [feat: Add page-attributes support to Team Members CPT](https://github.com/sanruiz/fibra/pull/212) - Merged (Copilot Agent)
+
+---
+
 ## [3.1.20] - 2026-01-15
 
 ### Portfolio Elementor Support & Image Optimizations


### PR DESCRIPTION
## Description

Adds the missing release notes for v3.1.21 to CHANGELOG.md. This release was created via GitHub Actions on 2026-01-17 but the CHANGELOG was not updated at that time.

## Changes

### v3.1.21 - 2026-01-17 - Team Members Menu Order Support

- **✨ Added**: `page-attributes` support to Team Members CPT (PR #212)
  - Enables `menu_order` field in WordPress admin
  - Allows manual ordering of team members
  - Enables Elementor "Order By: Menu Order" functionality
  
- **✨ Added**: TeamMembersTest.php unit test file
  - Tests singleton instance pattern
  - Tests post type registration
  - Tests supports array includes `page-attributes`
  
- **🐛 Fixed**: Corrected expected value assertions in TeamMembersTest

## Related

- **PR #212**: [feat: Add page-attributes support to Team Members CPT](https://github.com/sanruiz/fibra/pull/212) (Copilot Agent)
- **Release**: v3.1.21 was published 2026-01-17

## Checklist

- [x] Documentation only change
- [x] Follows CHANGELOG format conventions
- [x] No code changes