### PR TITLE
chore(release): Prepare release v3.1.29

### DIFF
--- a/wp-content/themes/soma/CHANGELOG.md
+++ b/wp-content/themes/soma/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.29] - 2026-06-19
+
+### Home Events Query Optimization
+
+This patch release improves the automatic event listing on the FibraSoma homepage.
+
+---
+
+### ⚡ Performance
+
+#### Home Events Partial
+
+- **Automatic Events Query** - Filter upcoming and active events directly in the WordPress query
+  - Limits the homepage events query to the four displayed posts
+  - Compares ACF date picker values using the stored `Ymd` format
+  - Preserves ongoing events by checking both start and end dates
+
+### 📦 Files Changed
+
+#### Modified
+
+- `partials/FibrasomaHomeEvents.php` - Query upcoming and active events at the database level
+
+---
+
 ## [3.1.28] - 2026-02-12
 
 ### Footer Social Menu Enhancement

--- a/wp-content/themes/soma/partials/FibrasomaHomeEvents.php
+++ b/wp-content/themes/soma/partials/FibrasomaHomeEvents.php
@@ -76,26 +76,37 @@ if ( get_query_var( 'soma_block_content' )['fill_mode'] === 'featured' ) {
 		}
 	}
 } else {
+	$today        = wp_date( 'Ymd' );
 	$events_query = get_posts(
 		array(
-			'numberposts' => -1,
+			'numberposts' => 4,
 			'post_type'   => 'events',
 			'post_status' => array( 'publish' ),
 			'order'       => 'ASC',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Event dates are stored in ACF post meta.
 			'meta_key'    => 'event_info_init_date',
 			'orderby'     => 'meta_value',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Event dates are stored in ACF post meta.
+			'meta_query'  => array(
+				'relation' => 'OR',
+				array(
+					'key'     => 'event_info_init_date',
+					'value'   => $today,
+					'compare' => '>=',
+					'type'    => 'CHAR',
+				),
+				array(
+					'key'     => 'event_info_end_date',
+					'value'   => $today,
+					'compare' => '>=',
+					'type'    => 'CHAR',
+				),
+			),
 		)
 	);
 	if ( $events_query ) {
-		$counter = 1;
-		foreach ( $events_query as $key => $item ) {
-			if ( $counter <= 4 ) {
-				$content = get_field( 'event_info', $item->ID );
-				if ( ( (int) $content['init_date'] + 86400 ) > (int) current_time( 'timestamp' ) || ( (int) $content['end_date'] + 86400 ) > (int) current_time( 'timestamp' ) ) {
-					$events[] = $item->ID;
-					++$counter;
-				}
-			}
+		foreach ( $events_query as $item ) {
+			$events[] = $item->ID;
 		}
 	}
 }

--- a/wp-content/themes/soma/phpstan.neon
+++ b/wp-content/themes/soma/phpstan.neon
@@ -18,7 +18,4 @@ parameters:
         # Allow missing array value types
         -
             identifier: missingType.iterableValue
-        # Allow missing generic types
-        -
-            identifier: missingType.generics
     treatPhpDocTypesAsCertain: false

--- a/wp-content/themes/soma/style.css
+++ b/wp-content/themes/soma/style.css
@@ -4,5 +4,5 @@ Theme URI: https://github.com/sanruiz/fibra
 Description: Modern WordPress theme with PSR-4 architecture, ACF flexible content, and Elementor integration.
 Author: Santiago Ramirez
 Author URI: https://github.com/sanruiz
-Version: 3.1.28
+Version: 3.1.29
 */


### PR DESCRIPTION
## Summary
Prepare SOMA theme release v3.1.29.

## Changes
- Optimize the FibraSoma homepage automatic events query to fetch only active/upcoming events.
- Compare ACF date picker values using the stored `Ymd` format.
- Bump theme version to `3.1.29`.
- Add CHANGELOG entry for v3.1.29.

## Testing
- [x] Ran `composer phpcs` (0 errors; 50 existing warnings outside the touched file)
- [x] Ran `vendor/bin/phpcs -s --report=full partials/FibrasomaHomeEvents.php` (0 errors, 0 warnings)
- [x] Ran `composer phpstan` (0 errors)
- [ ] Ran `composer test` (blocked: local WordPress test suite requires MySQL client; `mysql`/`mysqladmin` are not installed)
- [x] Ran `npm run prod` (build successful; webpack reported 2 existing bundle size warnings)

## Quality Checks
- PHPCS: 0 errors globally; touched file clean
- PHPStan: 0 errors
- PHPUnit: blocked locally by missing WordPress test DB tooling
- Frontend build: successful

## Related Issue
N/A

## Notes for Reviewers
The release branch was created from `develop` and targets `main` following the repo release workflow. Do not create the GitHub release manually; after this PR is merged to `main`, create and push the annotated `v3.1.29` tag from `main` to trigger the release workflow.
