### PR TITLE
fix(elementor): stabilize team member and breadcrumb widget styles

### DIFF
--- a/wp-content/themes/soma/assets/css/widgets/breadcrumb.css
+++ b/wp-content/themes/soma/assets/css/widgets/breadcrumb.css
@@ -14,7 +14,9 @@
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
-	padding: 70px 0 0 0;
+	max-width: var(--soma-container-max-width, 1280px);
+	margin: 0 auto;
+	padding: 70px var(--soma-spacing-md, 15px) 0 var(--soma-spacing-md, 15px);
 	font-size: var(--soma-font-size-small, 16px);
 	line-height: 1.5;
 	letter-spacing: 0;

--- a/wp-content/themes/soma/assets/css/widgets/team-member.css
+++ b/wp-content/themes/soma/assets/css/widgets/team-member.css
@@ -60,19 +60,27 @@
 
 .soma-team-member .member-name {
 	font-family: var(--soma-font-family-primary);
-	font-size: var(--soma-font-size-h2);
-	font-weight: var(--soma-font-weight-bold);
-	line-height: var(--soma-line-height-tight);
+	font-size: var(--e-global-typography-primary-font-size, 4.2rem) !important;
+	font-weight: var(--e-global-typography-primary-font-weight, 400) !important;
+	line-height: var(--e-global-typography-primary-line-height, 4.2rem) !important;
 	color: var(--soma-color-text-primary);
-	margin-top: -10px;
+	margin-top: 0 !important;
+	margin-bottom: 21px !important;
+	position: static !important;
+	display: block !important;
+	clear: both;
 }
 
 .soma-team-member .member-title {
 	font-family: var(--soma-font-family-primary);
-	font-size: var(--soma-font-size-h4);
-	font-weight: var(--soma-font-weight-normal);
-	line-height: var(--soma-line-height-normal);
+	font-size: var(--e-global-typography-secondary-font-size, 1.7rem) !important;
+	font-weight: var(--e-global-typography-secondary-font-weight, 400) !important;
+	line-height: var(--e-global-typography-secondary-line-height, 2rem) !important;
 	color: var(--soma-color-text-secondary, #7E7E87);
+	margin: 0 !important;
+	position: static !important;
+	display: block !important;
+	clear: both;
 }
 
 /* Featured Image */


### PR DESCRIPTION
## Summary
Stabilizes Team Member single template rendering in production/local by making widget styles resilient to Elementor generated CSS drift.

## Changes
- Prevented member-name / member-title overlap in soma-team-member widget.
- Made Team Member typography follow Elementor global variables with static fallbacks.
- Made soma-breadcrumb widget boxed by default (self-contained, no dependency on Elementor container context).

## Validation
- Verified affected EN/ES Team Member URLs load patched CSS assets.
- Verified team-member.css and breadcrumb.css are served from production with updated rules.
- Verified no regressions on local synced environment.

## Related
Context: production visual regression on Team Members template (Elementor template ID 2201).
